### PR TITLE
Remove WE STOP BREACHES tagline from README footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,3 @@ The two plugins detect each other and advise the right path. Use `fusion-skills`
 ## License
 
 MIT — see [LICENSE](LICENSE) for details.
-
----
-
-<p align="center">WE STOP BREACHES</p>


### PR DESCRIPTION
The README footer ended with a centered `WE STOP BREACHES` tagline (and a horizontal-rule separator) that the sibling `foundry-skills` plugin does not have. Removing it for parity between the two plugins. Content-only change to the README footer; no code or skill behavior affected.