### PR TITLE
Strip employee metadata from two tutorial example workflows

### DIFF
--- a/skills/authoring/examples/tutorials/intro-cases-add-event.yaml
+++ b/skills/authoring/examples/tutorials/intro-cases-add-event.yaml
@@ -32,8 +32,6 @@ actions:
       config:
         description: ''
         end: now
-        last_modified_by: mirza.baig@crowdstrike.com
-        last_modified_timestamp: '2026-03-05T00:06:33.337Z'
         repo_or_view: search-all
         search_name: example queries
         search_query: '#repo = fusion

--- a/skills/authoring/examples/tutorials/intro-error-handling.yaml
+++ b/skills/authoring/examples/tutorials/intro-error-handling.yaml
@@ -32,9 +32,6 @@ actions:
       config:
         description: ''
         end: now
-        last_modified_by: 4a090c6f-0917-4a75-8617-7c6d514770b9
-        last_modified_by_user:
-          email: tim.kuhlman@crowdstrike.com
         repo_or_view: search-all
         search_name: example for error handling
         search_query: '#repo = "fusion"'


### PR DESCRIPTION
Removes non-functional `last_modified_by` / `last_modified_by_user` authoring metadata from the Event Query action config in two tutorial examples (`intro-cases-add-event.yaml` and `intro-error-handling.yaml`). These fields are captured at export time, carried CrowdStrike employee email addresses, play no role in the workflow, and should not ship in a public repo.

Both files still pass pre-flight, structural, and API validation. Surfaced during the pre-public code review.