### PR TITLE
Add export_workflow.py to export a deployed workflow definition to YAML

### DIFF
--- a/skills/deployment/scripts/export_workflow.py
+++ b/skills/deployment/scripts/export_workflow.py
@@ -1,0 +1,106 @@
+"""
+Export a CrowdStrike Fusion workflow definition to YAML.
+
+Fetches a deployed workflow definition by ID and writes its console
+import/export YAML — the same format the Falcon console produces via
+Workflows > (workflow) > Export. Use this to capture a live workflow as a
+reproducible artifact, verify what a deployed definition actually contains,
+or ground a new example in a real export.
+
+By default the export is PII-sanitized: the platform strips authoring
+metadata such as `last_modified_by` / `last_modified_by_user` (which can carry
+an author's email) before returning the YAML. Pass --no-sanitize only when you
+deliberately need the raw definition and understand it may contain PII.
+
+Usage:
+    python export_workflow.py <definition_id>                 # sanitized YAML to stdout
+    python export_workflow.py <definition_id> -o wf.yaml      # write to a file
+    python export_workflow.py <definition_id> --no-sanitize   # raw (may contain PII)
+"""
+
+import argparse
+import os
+import sys
+
+# Add the shared common/scripts directory (two levels up) to sys.path so the
+# auth module resolves no matter where this script is launched from.
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "..", "..", "..", "common", "scripts",
+    ),
+)
+import _bootstrap  # pylint: disable=wrong-import-position
+_bootstrap.ensure_deps(__file__)  # re-exec via managed venv if deps are missing
+from auth import get_client  # pylint: disable=wrong-import-position
+
+# Fix Windows console encoding
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+
+def export_definition(definition_id, sanitize=True):
+    """Export one workflow definition as YAML text.
+
+    Returns the export as a decoded string. The Fusion export endpoint returns
+    raw YAML bytes (not a JSON envelope), so bytes are decoded directly; a JSON
+    error envelope is surfaced as a RuntimeError.
+    """
+    client = get_client()
+    resp = client.export_definition(id=definition_id, sanitize=sanitize)
+
+    # Success returns raw YAML bytes. An error returns a JSON dict envelope.
+    if isinstance(resp, (bytes, bytearray)):
+        return resp.decode("utf-8", "replace")
+
+    if isinstance(resp, dict):
+        status = resp.get("status_code")
+        body = resp.get("body", resp)
+        if isinstance(body, (bytes, bytearray)):
+            return body.decode("utf-8", "replace")
+        errors = body.get("errors") if isinstance(body, dict) else None
+        raise RuntimeError(
+            f"Export failed (status {status}): {errors or body}"
+        )
+
+    return str(resp)
+
+
+def main():
+    """CLI entry point for exporting a workflow definition."""
+    parser = argparse.ArgumentParser(
+        description="Export a Fusion workflow definition to YAML"
+    )
+    parser.add_argument(
+        "definition_id",
+        help="The 32-char hex ID of the workflow definition to export",
+    )
+    parser.add_argument(
+        "--output", "-o", metavar="FILE",
+        help="Write the YAML to this file (default: stdout)",
+    )
+    parser.add_argument(
+        "--no-sanitize", dest="sanitize", action="store_false",
+        help="Do NOT strip PII/authoring metadata (default: sanitize). "
+             "The raw export may contain an author's email.",
+    )
+    parser.set_defaults(sanitize=True)
+    args = parser.parse_args()
+
+    try:
+        yaml_text = export_definition(args.definition_id, sanitize=args.sanitize)
+    except RuntimeError as exc:
+        print(f"  {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(yaml_text)
+        note = "" if args.sanitize else " (raw, not sanitized)"
+        print(f"  Exported {args.definition_id} to {args.output}{note}")
+    else:
+        print(yaml_text)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_export_workflow.py
+++ b/tests/test_export_workflow.py
@@ -1,0 +1,128 @@
+"""Tests for export_workflow.py — export decoding, sanitize flag, error
+envelope handling, and the CLI file/stdout paths."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import export_workflow
+
+
+class TestExportDefinition:
+    """Test export_definition against a mocked client."""
+
+    def test_returns_decoded_bytes(self, monkeypatch):
+        """A successful export returns raw YAML bytes, decoded to str."""
+        mock_client = MagicMock()
+        mock_client.export_definition.return_value = b"name: Example\ntrigger: {}\n"
+        monkeypatch.setattr(export_workflow, "get_client", lambda: mock_client)
+
+        result = export_workflow.export_definition("abc123")
+
+        assert result == "name: Example\ntrigger: {}\n"
+        mock_client.export_definition.assert_called_once_with(
+            id="abc123", sanitize=True
+        )
+
+    def test_sanitize_flag_passed_through(self, monkeypatch):
+        """--no-sanitize surfaces as sanitize=False on the API call."""
+        mock_client = MagicMock()
+        mock_client.export_definition.return_value = b"name: Raw\n"
+        monkeypatch.setattr(export_workflow, "get_client", lambda: mock_client)
+
+        export_workflow.export_definition("abc123", sanitize=False)
+
+        mock_client.export_definition.assert_called_once_with(
+            id="abc123", sanitize=False
+        )
+
+    def test_dict_body_with_bytes(self, monkeypatch):
+        """A dict envelope whose body is bytes is decoded."""
+        mock_client = MagicMock()
+        mock_client.export_definition.return_value = {
+            "status_code": 200,
+            "body": b"name: FromDict\n",
+        }
+        monkeypatch.setattr(export_workflow, "get_client", lambda: mock_client)
+
+        assert export_workflow.export_definition("abc123") == "name: FromDict\n"
+
+    def test_error_envelope_raises(self, monkeypatch):
+        """A JSON error envelope raises RuntimeError with the status and errors."""
+        mock_client = MagicMock()
+        mock_client.export_definition.return_value = {
+            "status_code": 404,
+            "body": {"errors": [{"code": 404, "message": "not found"}]},
+        }
+        monkeypatch.setattr(export_workflow, "get_client", lambda: mock_client)
+
+        with pytest.raises(RuntimeError) as exc:
+            export_workflow.export_definition("missing")
+        assert "404" in str(exc.value)
+        assert "not found" in str(exc.value)
+
+    def test_non_bytes_non_dict_stringified(self, monkeypatch):
+        """An unexpected response type is coerced to str rather than crashing."""
+        mock_client = MagicMock()
+        mock_client.export_definition.return_value = "already a string"
+        monkeypatch.setattr(export_workflow, "get_client", lambda: mock_client)
+
+        assert export_workflow.export_definition("abc123") == "already a string"
+
+
+class TestMainCLI:
+    """Test the CLI entry point: stdout, file output, and error exit."""
+
+    def test_stdout_output(self, monkeypatch, capsys):
+        """With no --output, the YAML is printed to stdout."""
+        monkeypatch.setattr(
+            export_workflow, "export_definition", lambda did, sanitize=True: "name: X\n"
+        )
+        monkeypatch.setattr("sys.argv", ["export_workflow.py", "abc123"])
+
+        export_workflow.main()
+
+        assert "name: X" in capsys.readouterr().out
+
+    def test_file_output(self, monkeypatch, capsys, tmp_path):
+        """With --output, the YAML is written to the file and a note is printed."""
+        monkeypatch.setattr(
+            export_workflow, "export_definition", lambda did, sanitize=True: "name: Y\n"
+        )
+        out = tmp_path / "wf.yaml"
+        monkeypatch.setattr(
+            "sys.argv", ["export_workflow.py", "abc123", "-o", str(out)]
+        )
+
+        export_workflow.main()
+
+        assert out.read_text(encoding="utf-8") == "name: Y\n"
+        assert str(out) in capsys.readouterr().out
+
+    def test_no_sanitize_note(self, monkeypatch, capsys, tmp_path):
+        """--no-sanitize adds a '(raw, not sanitized)' note to the file message."""
+        monkeypatch.setattr(
+            export_workflow, "export_definition", lambda did, sanitize=False: "name: Z\n"
+        )
+        out = tmp_path / "raw.yaml"
+        monkeypatch.setattr(
+            "sys.argv",
+            ["export_workflow.py", "abc123", "--no-sanitize", "-o", str(out)],
+        )
+
+        export_workflow.main()
+
+        assert "not sanitized" in capsys.readouterr().out
+
+    def test_error_exits_nonzero(self, monkeypatch, capsys):
+        """A RuntimeError from export surfaces as exit code 1."""
+        def _raise(did, sanitize=True):
+            raise RuntimeError("Export failed (status 404): boom")
+
+        monkeypatch.setattr(export_workflow, "export_definition", _raise)
+        monkeypatch.setattr("sys.argv", ["export_workflow.py", "missing"])
+
+        with pytest.raises(SystemExit) as exc:
+            export_workflow.main()
+        assert exc.value.code == 1
+        assert "Export failed" in capsys.readouterr().err


### PR DESCRIPTION
Adds `export_workflow.py` to the deployment skill, wrapping FalconPy `export_definition`. The skill could import, release, and delete definitions but had no way to export one — this closes that gap.

It fetches a deployed definition and writes console import/export YAML (the same format the console Export button produces), for capturing a live workflow as a reproducible artifact or verifying what a deployed definition actually contains.

The export is PII-sanitized by default (the platform strips `last_modified_by` / `last_modified_by_user` authoring metadata, which can carry an author's email); `--no-sanitize` opts into the raw definition. Registered in the deployment SKILL.md script reference with a usage section. 9 unit tests (98% coverage on the new file); pylint 10.00/10 and the full suite (516 tests, 93.5% coverage) pass.