### PR TITLE
Add ngsiem-detection-response use case

### DIFF
--- a/skills/workflows/SKILL.md
+++ b/skills/workflows/SKILL.md
@@ -199,8 +199,10 @@ Available use cases:
 | `detection-deduplication` | Find and close duplicate Next-Gen SIEM detections with an Event Query dedup |
 | `case-management` | Query relevant events and attach them to a Next-Gen SIEM Case |
 | `identity-detection-response` | Respond to an Identity Protection detection: get user context, then resolve or notify |
+| `ngsiem-detection-response` | Respond to an NG-SIEM detection: hydrate it with an Event Query, extract fields, gate on a condition, summarize with an LLM, and email |
 | `lookup-file-management` | Create/overwrite/append/update a lookup file from inside a workflow |
 | `notifications` | Send a workflow notification to a chat channel (e.g. Slack) |
+| `charlotte-agent-invocation` | Automatically invoke a published Charlotte AI (AgentWorks) agent when a detection fires |
 
 A use case names the sub-skills it needs in its `skills:` frontmatter — use that to plan
 which phases to coordinate.

--- a/use-cases/README.md
+++ b/use-cases/README.md
@@ -33,6 +33,7 @@ to coordinate.
 | [lookup-file-management](lookup-file-management.md) | Create/overwrite/append/update a lookup file from inside a workflow |
 | [notifications](notifications.md) | Send a workflow notification to a chat channel (e.g. Slack) |
 | [charlotte-agent-invocation](charlotte-agent-invocation.md) | Automatically invoke a published Charlotte AI (AgentWorks) agent when a detection fires |
+| [ngsiem-detection-response](ngsiem-detection-response.md) | Respond to an NG-SIEM detection: filter, hydrate, extract, gate, summarize with Charlotte AI, and email |
 
 ## File Format
 

--- a/use-cases/ngsiem-detection-response.md
+++ b/use-cases/ngsiem-detection-response.md
@@ -1,0 +1,99 @@
+---
+name: ngsiem-detection-response
+description: Automatically respond to a Next-Gen SIEM detection in a Falcon Fusion workflow - filter by source, hydrate the detection with an event query, extract fields, gate on a condition, then summarize with Charlotte AI and email the team
+source: CrowdStrike "Fusion SOAR Automated Response Quick Start Guide" (https://docs.crowdstrike.com/r/en-US/edd8jdz1/z8tzddxk)
+skills: [authoring, deployment, execution]
+capabilities: [workflow, ngsiem-detection, event-query, charlotte-ai, notification]
+---
+
+## When to Use
+
+User wants a workflow that fires on a Next-Gen SIEM detection, pulls the full
+detection context, applies conditional logic (for example, "only act when file
+activity is outside business hours"), then uses Charlotte AI to summarize the
+event and emails the summary to a team. This is the end-to-end
+detect-and-respond pipeline: trigger -> filter -> hydrate -> extract -> gate ->
+summarize -> notify.
+
+This is grounded in the published CrowdStrike *Fusion SOAR Automated Response
+Quick Start Guide*, which walks through exactly this pipeline for after-hours
+file-activity detections. The mechanics below (hydration join key, Charlotte AI
+decode path, HTML-email formatting) are cross-referenced to the reference docs
+where each is covered in depth and verified live.
+
+## Pattern
+
+1. **Trigger on the NG-SIEM Detection.** Use a Signal trigger on the `Detection`
+   category, `event: Investigatable/NGSIEM`. Mock the trigger with Custom JSON so
+   you can iterate without waiting for a real detection. See
+   `references/trigger-types.md`.
+2. **Filter with a condition (fail closed).** Add a condition that continues only
+   for the detections you care about (the guide checks `Vendors includes
+   Anthropic`); the ELSE branch ends the workflow (or prints a "no action"
+   message). A condition MUST have both a TRUE path and an ELSE/default, or
+   release validation rejects it - see `references/yaml-schema.md`.
+3. **Hydrate with an event query.** The Signal trigger carries common fields but
+   not the full detection. Query Next-Gen SIEM to get the rest. **Match the
+   trigger's composite `DetectionID` against `Ngsiem.alert.id`, NOT
+   `Ngsiem.detection.id`** (a query keyed on `detection.id` silently returns zero
+   rows). When the detection is built on a third-party data connector, query that
+   connector's underlying events (e.g. `Ngsiem.alert.id = ?detectID` plus the
+   vendor event/activity filters) rather than the detection record. Which
+   detection types can be hydrated by Event Query versus need a Get Detection
+   Details action is covered in `references/event-query-vs-api.md` - read it
+   before authoring the query.
+4. **Extract variables from the results.** Create variables (with explicit types)
+   and populate them from the query results with CEL - e.g. parse a timestamp with
+   `.substring(...)`, or filter-and-map an array of IPs with
+   `.filter(...).map(...).distinct()`. Defensive CEL (null/size guards before
+   indexing) is covered in `use-cases/event-queries.md` and
+   `references/cel-expressions.md`.
+5. **Gate on the extracted values.** Add a second condition on the extracted
+   variables (the guide checks whether the event hour falls outside business
+   hours). ELSE prints a "no unusual activity" message and ends.
+6. **Summarize with Charlotte AI.** Add a Charlotte AI - LLM Completion action.
+   Pass the query results as input, instruct the model to return raw JSON (no
+   markdown, no code fences) and an HTML email body, and read decoded fields
+   downstream with
+   `cs.json.decode(data['<Node>.FaaS.nlpassistantapi.llminvocator_handler.completion']).<field>`.
+   The decode path, the "no code fence" instruction, and HTML-email formatting are
+   covered in `references/charlotte-ai-action.md` and
+   `use-cases/http-actions.md` (LLM formatting section).
+7. **Notify.** Send the decoded `subject` and `html_email` via a Send email action
+   with `msg_type: html`. Prompt the user for the recipient - never hardcode one.
+8. **Validate, then deploy.** Run `validate.py`, import, test with mock data, and
+   release. See the deployment skill.
+
+## Key Actions
+
+| Action | Role | Notes |
+|--------|------|-------|
+| NG-SIEM Detection (Signal trigger) | Starts the workflow on a detection | `event: Investigatable/NGSIEM`; mock via Custom JSON |
+| Event Query (`Inline.QueryEvent`) | Hydrates the detection context | Join on `Ngsiem.alert.id`; go schemaless |
+| Create variable / Update variable | Extract and transform fields with CEL | Guard nulls/size before indexing |
+| Charlotte AI - LLM Completion | Summarizes the event | Compound ID, `~0`; needs Charlotte AI credits; decode the completion |
+| Send email | Delivers the summary | `msg_type: html`; ask the user for the recipient |
+
+## Gotchas
+
+- **Hydration join key is detection-type-dependent.** `Ngsiem.alert.id` works for
+  first/third-party detections (and for querying a correlation detection's
+  underlying connector events); a correlation *detection record* with no queryable
+  underlying events needs a Get Detection Details action instead. This is the most
+  common silent-empty failure - see `references/event-query-vs-api.md`.
+- **Charlotte AI needs credits**, and the org must opt in. A workflow that invokes
+  it will not produce a summary in a tenant without them.
+- **Business-hours logic:** the guide implements the time gate as hardcoded
+  UTC-hour OR-branches (`EventHourPT == "07"` ... `"13"` for a PT location). That
+  works but is brittle across time zones; prefer a numeric comparison on the
+  extracted hour where practical.
+- **Email recipient:** prompt for it. Send email only delivers to Falcon users and
+  approved domains, so a placeholder like `user@example.com` fails at runtime.
+
+## When to Route Elsewhere
+
+Fetching a *population* of detections the workflow does not already hold ("all
+high-severity detections today") is a Falcon platform API call (CrowdStrike HTTP
+Request), not an Event Query - see `use-cases/http-actions.md` and
+`references/event-query-vs-api.md`. Keep this use case for responding to a single
+detection that fired the trigger.

--- a/use-cases/ngsiem-detection-response.md
+++ b/use-cases/ngsiem-detection-response.md
@@ -1,7 +1,7 @@
 ---
 name: ngsiem-detection-response
 description: Automatically respond to a Next-Gen SIEM detection in a Falcon Fusion workflow - filter by source, hydrate the detection with an event query, extract fields, gate on a condition, then summarize with Charlotte AI and email the team
-source: CrowdStrike "Fusion SOAR Automated Response Quick Start Guide" (https://docs.crowdstrike.com/r/en-US/edd8jdz1/z8tzddxk)
+source: CrowdStrike "Fusion SOAR Automated Response Quick Start Guide" (https://docs.crowdstrike.com/access?ft:originId=z8tzddxk)
 skills: [authoring, deployment, execution]
 capabilities: [workflow, ngsiem-detection, event-query, charlotte-ai, notification]
 ---


### PR DESCRIPTION
Adds a use case for the end-to-end NG-SIEM detect-and-respond pipeline: Signal trigger on an NG-SIEM Detection, condition to filter by source, event-query hydration, variable extraction with CEL, a second condition gate, Charlotte AI summary, and an HTML email.

Grounded in the published CrowdStrike *Fusion SOAR Automated Response Quick Start Guide* (docs.crowdstrike.com/r/en-US/edd8jdz1/z8tzddxk). Rather than transcribing the guide's console steps, each mechanic is cross-referenced to the reference doc where it's covered in depth and verified live: the `Ngsiem.alert.id` hydration join key (event-query-vs-api.md), the Charlotte AI completion decode path (charlotte-ai-action.md), and HTML-email formatting (http-actions.md).

Docs-only: one new `use-cases/*.md` plus its README index row. markdownlint clean, frontmatter parses, source is the canonical public docs URL.

One open item, flagged in the commit and being confirmed with the guide's author: the guide hydrates a correlation-detection via `Ngsiem.alert.id`, which appears to query the underlying connector events rather than the detection record (consistent with our live finding that correlation *detection records* need Get Detection Details). The use case describes it that way; if the author's answer changes the nuance, a quick follow-up will adjust it.