### PR TITLE
Remove source links from reference files

### DIFF
--- a/skills/authoring/references/event-query-action.md
+++ b/skills/authoring/references/event-query-action.md
@@ -137,5 +137,4 @@ Foundry function when you need complex processing, pagination, or transformation
 logic — that path belongs to the `foundry-skills` plugin.
 
 See [use-cases/event-queries.md](../../use-cases/event-queries.md) for the full
-pattern, and the source blog: [Falcon Fusion Event Queries: When and How to
-Go Schemaless](https://www.crowdstrike.com/tech-hub/ng-siem/falcon-fusion-soar-event-queries-when-and-how-to-go-schemaless/).
+pattern.

--- a/skills/authoring/references/http-actions.md
+++ b/skills/authoring/references/http-actions.md
@@ -5,8 +5,6 @@ required. They cover the majority of API integrations: threat-intel enrichment,
 notifications, and data lookups. All three types share `class: Inline.HTTPRequest`
 and `version_constraint: ~1`.
 
-Source: [Build API Integrations with Falcon Fusion HTTP Actions](https://www.crowdstrike.com/tech-hub/ng-siem/build-api-integrations-with-falcon-fusion-soar-http-actions/).
-
 ## The three types
 
 | Type | Use for | Network | Auth |
@@ -76,8 +74,6 @@ attach a credential there. Then tell the user the console steps:
 > **API key** → API secret key: `<your key>` → API key location: **Header** →
 > Header name: `x-apikey` (per the API's docs) → **Test** → **Schema builder** →
 > Save. (If a matching credential already exists, pick **Use existing** instead.)
-
-Source: [Build API Integrations with Falcon Fusion SOAR HTTP Actions](https://www.crowdstrike.com/tech-hub/ng-siem/build-api-integrations-with-falcon-fusion-soar-http-actions/).
 
 **Never fabricate a `definition_id`.** A token like
 `VIRUSTOTAL_CREDENTIAL_CONFIG_ID` or any non-hex placeholder is a broken


### PR DESCRIPTION
Source links belong only in use-cases, which carry the canonical `source:` in frontmatter. This removes the three stray source links from two reference files:

- `skills/authoring/references/http-actions.md` (two copies of the same Tech Hub link)
- `skills/authoring/references/event-query-action.md` (the "Go Schemaless" Tech Hub link)

Both URLs are already the `source:` of their matching use case (`use-cases/http-actions.md` and `use-cases/event-queries.md`), so no provenance is lost. The event-query reference keeps its internal cross-reference to the use case. Documentation only.