### PR TITLE
Flag Event Query alert-population fetches against the alerts repo

### DIFF
--- a/skills/authoring/scripts/validate.py
+++ b/skills/authoring/scripts/validate.py
@@ -443,7 +443,7 @@ def _check_detection_hydration_join(label, config, issues):
 # queries against ordinary NG-SIEM telemetry (failed logins, custom parsers) that
 # name no alert repo.
 _ALERT_POPULATION_REPO_RE = re.compile(
-    r"xdr_indicatorsrepo|#repo\s*=\s*[\"']?detections|DetectionSummaryEvent",
+    r"xdr_indicatorsrepo|#repo\s*=\s*[\"']?(?:detections|alerts)|DetectionSummaryEvent",
     re.IGNORECASE,
 )
 _SEVERITY_FILTER_RE = re.compile(r"severity", re.IGNORECASE)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2423,6 +2423,39 @@ actions:
         issues = validate.structural_check(str(f))
         assert any("population" in i for i in issues)
 
+    def test_event_query_alerts_repo_population_flagged(self, tmp_path):
+        """An Event Query against the `alerts` repo + severity is a population fetch."""
+        f = tmp_path / "eq_alerts.yaml"
+        content = """\
+# Header
+name: Test
+trigger:
+  type: Scheduled
+  event: Schedule
+  next:
+    - Q
+  schedule:
+    time_cycle: "0 8 * * *"
+    tz: Etc/UTC
+actions:
+  Q:
+    id: cdf5c3e0d69f156eaaf56c1f5d3f1b66
+    class: Inline.QueryEvent
+    version_constraint: ~1
+    name: Query
+    properties:
+      logscale_search_start_time: 24 hours
+    inline_configuration:
+      config:
+        search_query: "#repo=alerts severity=High OR severity=high | groupBy([alert_id, name, severity])"
+        repo_or_view: search-all
+        start: 24h
+        end: now
+"""
+        f.write_text(content)
+        issues = validate.structural_check(str(f))
+        assert any("population" in i and "/alerts/queries/alerts/v2" in i for i in issues)
+
     def test_event_query_held_detection_enrichment_not_flagged(self, tmp_path):
         """Enriching a held detection (alert.id=?arg) in an alert repo is NOT a population."""
         f = tmp_path / "eq_held.yaml"


### PR DESCRIPTION
The `validate.py` alert-population guard flags an Event Query used to fetch a *population* of alerts a workflow does not already hold, steering the author to a CrowdStrike HTTP Request against `/alerts/queries/alerts/v2` instead (the NG-SIEM alerts repo is connector-dependent and can silently return zero rows on many tenants).

The guard matched `xdr_indicatorsrepo`, `#repo=detections`, and `DetectionSummaryEvent`, but not the `alerts` repo alias. So a scheduled "email a summary of all high-severity alerts" workflow that reached for `#repo=alerts severity=High` passed pre-flight, structural, and API validation and got all the way to release with the wrong action type. This adds `alerts` to the repo alternation so the guard fires and the author gets a local error to correct.

The held-detection-join exclusion is unchanged, so enriching a detection the workflow already holds (`Ngsiem.alert.id=?arg`) remains a legitimate Event Query. Verified zero false positives against the bundled examples, whose only repos are `xdr_indicatorsrepo`, `detections`, and `fusion`. Includes a regression test using the exact query shape that slipped through.