### PR TITLE
Accept --search as an alias for --events in trigger_search.py

### DIFF
--- a/skills/authoring/scripts/trigger_search.py
+++ b/skills/authoring/scripts/trigger_search.py
@@ -340,11 +340,14 @@ def main():
     group.add_argument(
         "--events",
         "-e",
+        "--search",
+        "-s",
         nargs="?",
         const="",
         metavar="QUERY",
         help="List Signal event sources (name -> event value) from the API, "
-        "optionally filtered by QUERY (e.g. --events detection)",
+        "optionally filtered by QUERY (e.g. --events detection). --search/-s is "
+        "an alias, mirroring action_search.py.",
     )
     group.add_argument(
         "--fields",

--- a/tests/test_trigger_search.py
+++ b/tests/test_trigger_search.py
@@ -199,6 +199,23 @@ class TestMainCli:
         assert json.loads(out) == [{"name": "Case", "event": "Case"}]
         assert seen["q"] == "case"
 
+    def test_search_alias_passes_query_to_events(self, monkeypatch, capsys):
+        """--search is an alias for --events (mirrors action_search.py)."""
+        seen = {}
+
+        def fake(q=None):
+            seen["q"] = q
+            return [{"name": "Case", "event": "Case"}]
+
+        monkeypatch.setattr(trigger_search, "search_event_triggers", fake)
+        monkeypatch.setattr(
+            "sys.argv", ["trigger_search.py", "--search", "case", "--json"]
+        )
+        trigger_search.main()
+        out = capsys.readouterr().out
+        assert json.loads(out) == [{"name": "Case", "event": "Case"}]
+        assert seen["q"] == "case"
+
     def test_events_empty_shows_notice(self, monkeypatch, capsys):
         monkeypatch.setattr(trigger_search, "search_event_triggers", lambda q=None: [])
         monkeypatch.setattr("sys.argv", ["trigger_search.py", "--events"])


### PR DESCRIPTION
`action_search.py` takes `--search "<query>"`; `trigger_search.py` takes `--events "<query>"` for the same fuzzy-lookup shape. That asymmetry is a reliable stumbling point: across a full eval run the model repeatedly typed `trigger_search.py --search` (mirroring the sibling script) and hit an argument error every time before self-correcting. It was the single most common CLI fumble in the transcripts — the tool didn't match a strong, reasonable expectation.

This aliases `--search`/`-s` to the existing `--events` action so the natural invocation just works. Behavior is unchanged and `--events` remains the documented primary form; `--search` is purely an accepted synonym. Includes a regression test asserting `--search <query>` routes to the events lookup.