### PR TITLE
Prepare docs for the 1.0.0 release, simplify the LLM-email example, and autofill required trigger inputs in verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-A tool-agnostic guide to the `fusion-skills` plugin for AI coding assistants that are **not** Claude Code (Codex, GitHub Copilot, Gemini, and others). Claude Code users get the same content via the plugin system and [CLAUDE.md](./CLAUDE.md); this file lets any agent use the skills directly.
+A tool-agnostic guide to the `fusion-skills` plugin for AI coding assistants that are **not** Claude Code (Codex, GitHub Copilot, Antigravity, and others). Claude Code users get the same content via the plugin system and [CLAUDE.md](./CLAUDE.md); this file lets any agent use the skills directly.
 
 ## What This Is
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,40 +4,33 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [1.0.0] - TBD
+## [1.0.0] - 2026-07-29
 
-Initial release of Falcon Fusion Skills — AI coding assistant skills for building CrowdStrike Falcon Fusion workflows.
+First public release of Falcon Fusion Skills — AI coding assistant skills for building CrowdStrike Falcon Fusion workflows. Describe the automation you want in plain language and your assistant discovers the real action IDs from your tenant, writes the YAML, validates it against the platform schema, imports it to your CID, and runs it.
 
 ### Skills
 
-- **workflows** — Orchestrator skill and single entry point. A decision tree routes intent to the right sub-skill and coordinates the full workflow lifecycle.
-- **authoring** — Live action discovery, workflow YAML authoring, CEL expressions (including `else`/`else_if` conditional routing), and structural schema validation. Documents HTTP Actions, Event Query (`Inline.QueryEvent`), Python Script (`Inline.Python`), and Charlotte AI LLM Completion actions. Signal triggers are documented with the required `event:` field (the trigger category, e.g. `Investigatable/NGSIEM`), which `trigger_search.py --events` discovers from the trigger catalog.
-- **deployment** — Duplicate checking, import to a CID, release, delete, and version management.
-- **execution** — Workflow triggering with payloads, execution monitoring, and result retrieval for debugging.
-- **lookup-files** — Create, list, get, update, and delete Falcon Next-Gen SIEM lookup files for CQL `match()` queries.
-- **setup** — Guided credential configuration that writes a multi-cloud TOML profile to `~/.cache/crowdstrike-falcon-fusion/credentials.toml`, with the secret entered through the user's own editor (never the chat).
+- **workflows** — Orchestrator and single entry point. Reads your intent and coordinates authoring, deployment, and execution.
+- **authoring** — Live action discovery, workflow YAML authoring, and schema validation. Covers conditional routing, HTTP Actions, Event Queries, inline Python, and Charlotte AI summaries.
+- **deployment** — Import to a CID, release, delete, and duplicate cleanup.
+- **execution** — Trigger a workflow, monitor it, and retrieve results for debugging.
+- **lookup-files** — Create, list, update, and delete the Next-Gen SIEM lookup files behind CQL `match()` queries.
+- **setup** — Guided credential configuration stored in a local profile, with the secret typed into your own editor rather than the chat.
 
-### Infrastructure
+### Validation
 
-- **Shared authentication** (`common/scripts/auth.py`) — Exposes both a Fusion Workflows client and a Next-Gen SIEM client, with credentials resolved from environment variables or a multi-CID TOML profile file.
-- **Structural validator** (`skills/authoring/scripts/validate.py`) — Pre-flight, structural, and API dry-run validation of workflow YAML without deploying, catching action-ID, trigger (including invalid trigger types like `On_demand` at pre-flight), reference, schema, off-schema top-level shape, scalar-`next` (the import API requires list form), disjoint-node (unreachable-from-trigger), per-action required-property errors (HTTP Request actions missing `request_http_method`/`request_content_type`, Charlotte AI LLM actions missing `user_prompt`/`model_name`, and Signal triggers carrying an unsupported `parameters` schema), and wrong-form data references (bare `$token`, shell-style `$(data[...])`) locally before a failed release.
-- **Cross-plugin hooks** — Advisory routing to and from the `crowdstrike-falcon-foundry` plugin, plus an intent router for the workflows skill.
-- **Test suite** — 507 unit tests across all 19 scripts (93% coverage, enforced at 90% in CI), plus `test-hooks.sh` and `test-validate.sh` for hook and structural checks.
-- **Lookup `match()` verification** (`skills/lookup-files/scripts/verify_lookup.py`) — a maintainer tool that uploads a lookup file, resolves a known row through a live CQL `match()` query, and deletes it, confirming the file is visible to `match()` end to end. Also wired into `verify-workflows.sh --lookup-dir`.
+- **Local validator** — Catches the mistakes that otherwise surface only at release time or as a silently empty result: bad action IDs, malformed references, the wrong trigger shape, and an Event Query pointed at data that isn't reliably there. You find out in seconds instead of after a failed deploy, and every check traces back to a real failure we hit and fixed.
 
 ### Examples
 
-25 Content Library workflow examples in YAML across six categories (threat intel, identity response, notifications, response actions, Next-Gen SIEM, and tutorials), each with resolved action IDs and every one verified to import cleanly via server-side validation. Examples are generated deterministically from Content Library catalog records by `bin/convert_catalog_to_yaml.py` (which flattens the BPMN-style graph into `trigger`/`actions`/`conditions`/`loops` and resolves the Signal `event:` value), so they are reproducible rather than hand-converted. The converter emits the console-renderable graph shape — parallel branches fan out via multi-target `next:`, exclusive gateways become a single `cel_expression` condition with an `else:` branch — so imported workflows also open cleanly in the Falcon visual editor, not just the API. Coverage includes a real parallel fan-out enrichment playbook (AbuseIPDB) and an `Inline.Python` script action (building a lookup file from an external feed).
+- 25 workflow examples from the CrowdStrike Content Library, spanning threat intel, identity response, notifications, response actions, Next-Gen SIEM, and tutorials. Every one imports cleanly and opens in the Falcon visual editor, so they double as working references.
 
 ### Use Cases
 
-14 pattern-matchable use cases in `use-cases/`, each with frontmatter naming its source and the sub-skills it needs. Some are drawn from published CrowdStrike Tech Hub posts; others are grounded directly in the bundled example workflows (detection enrichment, detection deduplication, human-in-the-loop containment, identity detection response, case management, lookup file management, and notifications) and corroborated by the community Workflow Wednesday series. Every action ID and `version_constraint` cited in a use case is traceable to its source example or flagged as a variation to resolve with `action_search.py`.
+- 15 pattern-matchable use cases that map common requests (enrich a detection, close duplicate detections, respond to an NG-SIEM detection) to the workflow that solves them, each grounded in a bundled example or a published CrowdStrike walkthrough.
 
-### Multi-Tool Support
+### Editor and CLI Support
 
-- **`AGENTS.md`** — Canonical, tool-agnostic Fusion workflow development guide.
-- **`CLAUDE.md`** — Claude Code-specific plugin additions.
-- **`GEMINI.md`** — Redirect for Gemini CLI.
-- **`.github/copilot-instructions.md`** — Redirect for GitHub Copilot.
+- Tested with Claude Code. Experimental setup instructions for Codex, Copilot CLI, Cursor, and Antigravity CLI, written from each tool's own documentation but not yet verified end to end. The skills are plain markdown, so any assistant that reads local files can use them.
 
 [1.0.0]: https://github.com/CrowdStrike/fusion-skills/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [1.0.0] - 2026-07-29
+## [1.0.0] - 2026-07-30
 
 First public release of Falcon Fusion Skills — AI coding assistant skills for building CrowdStrike Falcon Fusion workflows. Describe the automation you want in plain language and your assistant discovers the real action IDs from your tenant, writes the YAML, validates it against the platform schema, imports it to your CID, and runs it.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ AI coding assistant skills for building [CrowdStrike Falcon Fusion](https://www.
 ### Prerequisites
 
 - **CrowdStrike Account** with the **Workflow** API scope (plus **NGSIEM Lookup Files** for the lookup-files skill)
-- **AI Coding Assistant**: Claude Code, Codex, Copilot CLI, Cursor, Gemini CLI, or any tool that can read local reference documentation
+- **AI Coding Assistant**: Claude Code, Codex, Copilot CLI, Cursor, Antigravity CLI, or any tool that can read local reference documentation
 
 ### Claude Code (Tested)
 
@@ -80,7 +80,7 @@ mkdir -p ~/.agents/skills
 ln -s /path/to/fusion-skills/skills ~/.agents/skills/fusion-skills
 ```
 
-Restart Codex to discover the skills. See the [Codex skills docs](https://developers.openai.com/codex/skills) for details.
+Restart Codex to discover the skills. See the [Codex skills docs](https://learn.chatgpt.com/docs/build-skills) for details.
 
 ### Copilot CLI (Experimental)
 
@@ -114,18 +114,18 @@ EOF
 
 Cursor activates the rule automatically when your prompt matches the description.
 
-### Gemini CLI (Experimental)
+### Antigravity CLI (Experimental)
 
-Link the skills so Gemini discovers them as native Agent Skills:
+Link the skills so Antigravity discovers them as native Agent Skills:
 
 ```bash
 git clone https://github.com/CrowdStrike/fusion-skills.git
-gemini skills link /path/to/fusion-skills/skills --scope user
+agy skills link /path/to/fusion-skills/skills --scope user
 ```
 
-This creates symlinks in `~/.gemini/skills/` so all skills are available in every workspace. Use `--scope workspace` to install into the current project's `.gemini/skills/` instead. Verify with `gemini skills list` or `/skills list` inside a session.
+This creates symlinks in `~/.gemini/antigravity-cli/skills/` so all skills are available in every workspace. Use `--scope workspace` to install into the current project's `.agents/skills/` instead. Verify with `agy skills list` or `/skills list` inside a session.
 
-Gemini activates the right skill on demand based on your prompt.
+Antigravity activates the right skill on demand based on your prompt.
 
 ### Other Tools
 
@@ -137,9 +137,7 @@ These skills are plain markdown files. Any AI coding assistant that can read loc
 
 This prompt exercises the full lifecycle: action discovery, event queries, parallel HTTP Action enrichment, an LLM completion action, and validation:
 
-```
-Generate a Fusion workflow that will trigger from a NG-SIEM detection. The workflow should hydrate the detection using an event query to get the full details of the detection. If a user, host, domain, url, file indicator, or ip indicator is found, enrich each in parallel using HTTP calls to VirusTotal or DomainTools. Summarize the enrichment across all the TI providers using an LLM completion action and then send an email formatted in HTML.
-```
+> Generate a Falcon Fusion workflow that will trigger from a Falcon Next-Gen SIEM detection. The workflow should hydrate the detection using an event query to get the full details of the detection. If a user, host, domain, url, file indicator, or ip indicator is found, enrich each in parallel using HTTP calls to VirusTotal or DomainTools. Summarize the enrichment across all the threat intelligence providers using an LLM completion action and then send an email formatted in HTML.
 
 Describe what you want in plain language. You don't need to name a skill. The orchestrator picks the right one.
 

--- a/skills/authoring/examples/threat-intel/enrich-ip-virustotal-llm-email.yaml
+++ b/skills/authoring/examples/threat-intel/enrich-ip-virustotal-llm-email.yaml
@@ -129,7 +129,7 @@ actions:
             to:
                 - ${data['notify_email']}
             subject: "[Falcon Fusion] VirusTotal IP Enrichment Report - ${data['ip']}"
-            msg: "<html><body><h2>VirusTotal IP Enrichment Report</h2><p><strong>IP:</strong> ${data['ip']}</p><hr/><h3>Stored enrichment variable</h3><p>${data['WorkflowCustomVariable.ip_enrichment']}</p><hr/><h3>Charlotte AI Summary</h3><div>${data['SummarizeEnrichment.FaaS.nlpassistantapi.llminvocator_handler.completion']}</div></body></html>"
+            msg: "<html><body>${data['SummarizeEnrichment.FaaS.nlpassistantapi.llminvocator_handler.completion']}</body></html>"
             msg_type: html
         version_constraint: ~1
 output_fields: []

--- a/skills/execution/scripts/trigger_workflow.py
+++ b/skills/execution/scripts/trigger_workflow.py
@@ -10,6 +10,7 @@ Usage:
     python trigger_workflow.py --id <def_id> --params '{"device_id":"abc123"}'
     python trigger_workflow.py --id <def_id>                     # Interactive parameter prompt
     python trigger_workflow.py --id <def_id> --params '{}' --wait --timeout 120
+    python trigger_workflow.py --id <def_id> --autofill --email me@example.com --wait
 """
 
 import argparse
@@ -52,6 +53,82 @@ def get_workflow_params_schema(definition_id):
         return trigger.get("parameters", {}).get("properties", {})
     except (ConnectionError, RuntimeError, OSError):
         return None
+
+
+def get_trigger_parameters(definition_id):
+    """
+    Fetch the full On-demand parameter schema (properties AND required list).
+
+    Returns a (properties, required) tuple. Unlike get_workflow_params_schema,
+    which returns only the properties for interactive prompting, this exposes the
+    JSON-schema `required` array so callers can autofill the mandatory inputs a
+    workflow will reject an execution for if omitted.
+    """
+    try:
+        client = get_client()
+        resp = client.search_definitions(filter=f"id:'{definition_id}'")
+        resources = resp["body"].get("resources", [])
+        if not resources:
+            return {}, []
+        params = resources[0].get("trigger", {}).get("parameters", {})
+        return params.get("properties", {}) or {}, params.get("required", []) or []
+    except (ConnectionError, RuntimeError, OSError):
+        return {}, []
+
+
+def heuristic_value(field_name, field_schema):
+    """
+    Derive a schema-valid placeholder value for a required parameter.
+
+    Used by autofill_params to satisfy a workflow's required On-demand inputs
+    when no explicit override is supplied. The goal is a value that (a) matches
+    the declared JSON-schema type so input validation passes, and (b) is
+    semantically plausible for common indicator field names so an enrichment
+    workflow has something real to act on. Explicit overrides always win over
+    these guesses — see autofill_params.
+    """
+    ftype = (field_schema or {}).get("type", "string")
+
+    # Non-string types get a minimal schema-valid value regardless of name.
+    non_string = {"integer": 1, "number": 1, "boolean": False, "array": [], "object": {}}
+    if ftype in non_string:
+        return non_string[ftype]
+
+    # String-typed: guess by field name so indicator enrichment gets real input.
+    name = field_name.lower()
+    # Ordered (substring, value) pairs; first match wins.
+    guesses = [
+        ("email", "verify@example.com"),
+        ("ip", "185.220.101.1"),   # a Tor exit node — returns a real VirusTotal verdict
+        ("domain", "example.com"),
+        ("url", "https://example.com"),
+        ("sha256", "44d88612fea8a8f36de82e1278abb02f"),  # EICAR test-file MD5
+        ("hash", "44d88612fea8a8f36de82e1278abb02f"),
+    ]
+    for needle, value in guesses:
+        if needle in name:
+            return value
+    return "test"
+
+
+def autofill_params(params, properties, required, overrides=None):
+    """
+    Fill any required parameters missing from `params`.
+
+    Precedence for each missing required field: an explicit override (from the
+    caller) first, then a name/type heuristic. Fields already present in `params`
+    are left untouched. Returns a new merged dict; does not mutate the input.
+    """
+    merged = dict(params or {})
+    overrides = overrides or {}
+    for name in required:
+        if name in merged:
+            continue
+        if name in overrides:
+            merged[name] = overrides[name]
+        else:
+            merged[name] = heuristic_value(name, (properties or {}).get(name, {}))
+    return merged
 
 
 def prompt_for_params(schema):
@@ -154,6 +231,11 @@ def main():
     parser = argparse.ArgumentParser(description="Trigger a Fusion workflow")
     parser.add_argument("--id", required=True, metavar="DEF_ID", help="Workflow definition ID")
     parser.add_argument("--params", metavar="JSON", help="Execution parameters as JSON string")
+    parser.add_argument("--autofill", action="store_true",
+                        help="Fill any required trigger params missing from --params "
+                             "using name/type heuristics (non-interactive verification)")
+    parser.add_argument("--email", metavar="ADDR",
+                        help="Override value for email-type required params when --autofill is set")
     parser.add_argument("--wait", action="store_true", help="Poll for execution results")
     parser.add_argument("--timeout", type=int, default=120, help="Poll timeout in seconds (default: 120)")
     parser.add_argument("--json", action="store_true", help="Machine-readable JSON output")
@@ -162,10 +244,25 @@ def main():
     # Get parameters
     if args.params:
         params = json.loads(args.params)
+    elif args.autofill:
+        # --autofill is non-interactive: start empty and let autofill (below)
+        # populate the required inputs. Do NOT drop into the interactive prompt.
+        params = {}
     else:
         # Interactive mode
         schema = get_workflow_params_schema(args.id)
         params = prompt_for_params(schema)
+
+    # Autofill required params the caller did not supply. Used by the verify
+    # harness so an On-demand workflow with required inputs (e.g. ip,
+    # notify_email) is not rejected at input validation before any action runs.
+    if args.autofill:
+        properties, required = get_trigger_parameters(args.id)
+        overrides = {}
+        if args.email:
+            overrides = {n: args.email for n in required
+                         if "email" in n.lower()}
+        params = autofill_params(params, properties, required, overrides)
 
     print(f"\n  Executing workflow {args.id}")
     print(f"  Parameters: {json.dumps(params, indent=2)}")

--- a/test-skill.sh
+++ b/test-skill.sh
@@ -116,7 +116,7 @@ else
   EXAMPLE_WF_ID="<the definition id returned by import_workflows.py>"
 fi
 
-PROMPT="Generate a Fusion workflow that will trigger from a NG-SIEM detection. The workflow should hydrate the detection using an event query to get the full details of the detection. If a user, host, domain, url, file indicator, or ip indicator is found, enrich each in parallel using HTTP calls to VirusTotal or DomainTools. Summarize the enrichment across all the TI providers using an LLM completion action and then send an email formatted in HTML. Use the fusion-skills plugin: discover real action IDs with action_search.py (never guess or use PLACEHOLDER values), choose an appropriate trigger, and write valid workflow YAML with a version_constraint on every action. ${DEPLOY_INSTRUCTION} Pick a reasonable workflow name and proceed without asking me any questions.
+PROMPT="Generate a Falcon Fusion workflow that will trigger from a Falcon Next-Gen SIEM detection. The workflow should hydrate the detection using an event query to get the full details of the detection. If a user, host, domain, url, file indicator, or ip indicator is found, enrich each in parallel using HTTP calls to VirusTotal or DomainTools. Summarize the enrichment across all the threat intelligence providers using an LLM completion action and then send an email formatted in HTML. Use the fusion-skills plugin: discover real action IDs with action_search.py (never guess or use PLACEHOLDER values), choose an appropriate trigger, and write valid workflow YAML with a version_constraint on every action. ${DEPLOY_INSTRUCTION} Pick a reasonable workflow name and proceed without asking me any questions.
 
 When done, respond with valid JSON matching this schema:
 ${RESULT_SCHEMA}

--- a/tests/test_trigger_workflow.py
+++ b/tests/test_trigger_workflow.py
@@ -173,6 +173,192 @@ class TestPromptForParams:
         assert trigger_workflow.prompt_for_params(schema) == {"cfg": {"k": 1}}
 
 
+class TestGetTriggerParameters:
+    """Test retrieval of the full On-demand parameter schema (properties + required)."""
+
+    def test_properties_and_required_extracted(self, monkeypatch):
+        """Both the properties map and the required list are returned."""
+        mock_client = MagicMock()
+        mock_client.search_definitions.return_value = {
+            "body": {
+                "resources": [
+                    {
+                        "trigger": {
+                            "parameters": {
+                                "properties": {
+                                    "ip": {"type": "string"},
+                                    "notify_email": {"type": "string"},
+                                },
+                                "required": ["ip", "notify_email"],
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+        monkeypatch.setattr(trigger_workflow, "get_client", lambda: mock_client)
+        props, required = trigger_workflow.get_trigger_parameters("def_id")
+        assert props == {"ip": {"type": "string"}, "notify_email": {"type": "string"}}
+        assert required == ["ip", "notify_email"]
+
+    def test_empty_when_no_resources(self, monkeypatch):
+        """A definition ID with no matches returns empty containers, not None."""
+        mock_client = MagicMock()
+        mock_client.search_definitions.return_value = {"body": {"resources": []}}
+        monkeypatch.setattr(trigger_workflow, "get_client", lambda: mock_client)
+        assert trigger_workflow.get_trigger_parameters("def_id") == ({}, [])
+
+    def test_missing_required_defaults_to_empty_list(self, monkeypatch):
+        """A schema with properties but no required array yields an empty required list."""
+        mock_client = MagicMock()
+        mock_client.search_definitions.return_value = {
+            "body": {"resources": [{"trigger": {"parameters": {"properties": {"a": {}}}}}]}
+        }
+        monkeypatch.setattr(trigger_workflow, "get_client", lambda: mock_client)
+        props, required = trigger_workflow.get_trigger_parameters("def_id")
+        assert props == {"a": {}}
+        assert required == []
+
+    def test_empty_on_exception(self, monkeypatch):
+        """Errors while fetching degrade to empty containers."""
+        mock_client = MagicMock()
+        mock_client.search_definitions.side_effect = RuntimeError("boom")
+        monkeypatch.setattr(trigger_workflow, "get_client", lambda: mock_client)
+        assert trigger_workflow.get_trigger_parameters("def_id") == ({}, [])
+
+
+class TestHeuristicValue:
+    """Test schema-valid placeholder derivation for required params."""
+
+    def test_email_field_by_name(self):
+        assert "@" in trigger_workflow.heuristic_value("notify_email", {"type": "string"})
+
+    def test_ip_field_by_name(self):
+        assert trigger_workflow.heuristic_value("ip", {"type": "string"}) == "185.220.101.1"
+
+    def test_domain_field_by_name(self):
+        assert trigger_workflow.heuristic_value("domain", {"type": "string"}) == "example.com"
+
+    def test_url_field_by_name(self):
+        assert trigger_workflow.heuristic_value("url", {"type": "string"}).startswith("http")
+
+    def test_hash_field_by_name(self):
+        assert trigger_workflow.heuristic_value("file_hash", {"type": "string"})
+
+    def test_integer_type(self):
+        assert trigger_workflow.heuristic_value("count", {"type": "integer"}) == 1
+
+    def test_boolean_type(self):
+        assert trigger_workflow.heuristic_value("flag", {"type": "boolean"}) is False
+
+    def test_array_type(self):
+        assert trigger_workflow.heuristic_value("ids", {"type": "array"}) == []
+
+    def test_object_type(self):
+        assert trigger_workflow.heuristic_value("cfg", {"type": "object"}) == {}
+
+    def test_unknown_string_field(self):
+        assert trigger_workflow.heuristic_value("whatever", {"type": "string"}) == "test"
+
+    def test_missing_schema_defaults_to_string(self):
+        """A None field_schema is treated as a string type."""
+        assert trigger_workflow.heuristic_value("whatever", None) == "test"
+
+
+class TestAutofillParams:
+    """Test required-param autofill precedence and non-mutation."""
+
+    def test_fills_missing_required_via_heuristic(self):
+        props = {"ip": {"type": "string"}, "notify_email": {"type": "string"}}
+        result = trigger_workflow.autofill_params({}, props, ["ip", "notify_email"])
+        assert result["ip"] == "185.220.101.1"
+        assert "@" in result["notify_email"]
+
+    def test_override_wins_over_heuristic(self):
+        props = {"notify_email": {"type": "string"}}
+        result = trigger_workflow.autofill_params(
+            {}, props, ["notify_email"], overrides={"notify_email": "me@corp.com"}
+        )
+        assert result["notify_email"] == "me@corp.com"
+
+    def test_existing_param_not_overwritten(self):
+        """A value already supplied in params is left untouched."""
+        props = {"ip": {"type": "string"}}
+        result = trigger_workflow.autofill_params(
+            {"ip": "8.8.8.8"}, props, ["ip"], overrides={"ip": "1.1.1.1"}
+        )
+        assert result["ip"] == "8.8.8.8"
+
+    def test_optional_fields_not_filled(self):
+        """Only required fields are autofilled; optional properties are ignored."""
+        props = {"ip": {"type": "string"}, "note": {"type": "string"}}
+        result = trigger_workflow.autofill_params({}, props, ["ip"])
+        assert "ip" in result
+        assert "note" not in result
+
+    def test_does_not_mutate_input(self):
+        original = {"a": 1}
+        trigger_workflow.autofill_params(original, {"ip": {}}, ["ip"])
+        assert original == {"a": 1}
+
+    def test_empty_required_returns_copy_of_params(self):
+        result = trigger_workflow.autofill_params({"a": 1}, {}, [])
+        assert result == {"a": 1}
+
+
+class TestMainAutofill:
+    """Test that --autofill wires schema retrieval into the params passed to execute."""
+
+    def test_autofill_fills_required_and_applies_email_override(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            "sys.argv",
+            ["trigger_workflow.py", "--id", "def_id", "--autofill",
+             "--email", "me@corp.com"],
+        )
+        monkeypatch.setattr(
+            trigger_workflow, "get_trigger_parameters",
+            lambda *_a, **_k: (
+                {"ip": {"type": "string"}, "notify_email": {"type": "string"}},
+                ["ip", "notify_email"],
+            ),
+        )
+        captured = {}
+
+        def fake_execute(def_id, params, *_a, **_k):
+            captured["params"] = params
+            return True, "exec_1", {}
+
+        monkeypatch.setattr(trigger_workflow, "execute_workflow", fake_execute)
+        trigger_workflow.main()
+        assert captured["params"]["ip"] == "185.220.101.1"
+        assert captured["params"]["notify_email"] == "me@corp.com"
+
+    def test_autofill_merges_with_explicit_params(self, monkeypatch):
+        """--autofill only fills what --params did not already supply."""
+        monkeypatch.setattr(
+            "sys.argv",
+            ["trigger_workflow.py", "--id", "def_id", "--params",
+             '{"ip":"9.9.9.9"}', "--autofill"],
+        )
+        monkeypatch.setattr(
+            trigger_workflow, "get_trigger_parameters",
+            lambda *_a, **_k: (
+{"ip": {"type": "string"}, "notify_email": {"type": "string"}},
+                ["ip", "notify_email"],
+            ),
+        )
+        captured = {}
+
+        def fake_execute(def_id, params, *_a, **_k):
+            captured["params"] = params
+            return True, "exec_1", {}
+
+        monkeypatch.setattr(trigger_workflow, "execute_workflow", fake_execute)
+        trigger_workflow.main()
+        assert captured["params"]["ip"] == "9.9.9.9"
+        assert "notify_email" in captured["params"]
+
+
 class TestPollResults:
     """Test result polling logic (time.sleep mocked for speed)."""
 

--- a/use-cases/http-actions.md
+++ b/use-cases/http-actions.md
@@ -76,7 +76,12 @@ renders as literal `##` and `**` in an HTML email. Three tiers, cleanest last:
    action to `msg_type: html`. The summary then renders with real headings and lists instead of raw
    Markdown. Note the explicit "no code fences" part: `Format the response in HTML` alone often makes
    the model wrap its output in a ` ```html ` fence, which then shows up literally in the email
-   (verified live). The shipped
+   (verified live). **Let the LLM completion BE the email body — don't rebuild a parallel template
+   in the Send email action.** Since the model already emits the formatted HTML report, the `msg`
+   should just wrap the completion: `msg: "<html><body>${data['<Node>.FaaS.nlpassistantapi.llminvocator_handler.completion']}</body></html>"`.
+   Re-templating the enrichment fields inline (a second `<h3>` table of the same variables the LLM
+   already summarized) is redundant and drifts from the model's output; forward the completion and
+   let it own the layout. The shipped
    `../skills/authoring/examples/threat-intel/enrich-ip-virustotal-llm-email.yaml` example uses this
    approach (the enrichment path — VT call → variable → summary → email — is verified live
    end-to-end).

--- a/verify-workflows.sh
+++ b/verify-workflows.sh
@@ -674,7 +674,12 @@ if [ "${#DEFERRED_EXEC[@]}" -gt 0 ]; then
       D_NAME="${entry#*|}"; D_NAME="${D_NAME%|*}"
       D_ID="${entry##*|}"
       D_EXEC="FAIL"; D_RESULTS="FAIL"; D_NOTE=""
-      if EXEC_OUT="$("$PYTHON" "$TRIGGER_PY" --id "$D_ID" --params '{}' --wait --timeout "$TIMEOUT" 2>&1)"; then
+      # On-demand workflows can declare required trigger inputs (e.g. ip,
+      # notify_email). Executing with an empty payload would be rejected at
+      # input validation before any action runs, so --autofill fills every
+      # required param the workflow declares (email-type fields get LOGIN_EMAIL;
+      # ip/domain/hash/etc. get schema-valid indicator values).
+      if EXEC_OUT="$("$PYTHON" "$TRIGGER_PY" --id "$D_ID" --autofill ${LOGIN_EMAIL:+--email "$LOGIN_EMAIL"} --wait --timeout "$TIMEOUT" 2>&1)"; then
         EXEC_ID="$(printf '%s\n' "$EXEC_OUT" | grep -oE 'Execution ID: .+' | head -1 | sed 's/Execution ID: //' | tr -d '[:space:]')"
         D_EXEC="PASS"
         if [ -n "$EXEC_ID" ] && RESULT_OUT="$("$PYTHON" "$RESULTS_PY" --execution-id "$EXEC_ID" --json 2>&1)"; then

--- a/verify-workflows.sh
+++ b/verify-workflows.sh
@@ -396,6 +396,14 @@ for wf_file in "${YAML_FILES[@]}"; do
   elif [ -z "$DEF_ID" ]; then
     C_STATUS="N/A"
     say "  cleanup:   ${YELLOW}N/A${RESET} (nothing deployed)"
+  elif [ "$E_STATUS" = "PENDING" ]; then
+    # Credential-gated On-demand workflow: its API execute is deferred until
+    # after Phase 2 configures the credential. Deleting it now — before that
+    # deferred run — would make the execute fail with "definition ... not
+    # found". Defer the delete to the post-Phase-2 cleanup, which runs after
+    # the deferred execute.
+    C_STATUS="PENDING"
+    say "  cleanup:   ${YELLOW}DEFERRED${RESET} (will delete after Phase 2 execute)"
   else
     # Delete by NAME via the Workflows delete API (delete_definitions).
     if DEL_OUT="$(delete_workflow "$WF_NAME" 2>&1)"; then
@@ -513,6 +521,15 @@ if [ "$BROWSER_VERIFY" = "1" ] && [ "$JSON_ONLY" != "1" ]; then
         read -rsp "  Enter VirusTotal API key (input hidden): " VIRUSTOTAL_API_KEY
         printf "\n" >&2
       fi
+      # The browser opens a FRESH context with no saved SSO session, so the
+      # login email field is EMPTY. Offer the agent the email to type so it can
+      # sign in on its own; otherwise it waits for the human. Set FALCON_LOGIN_EMAIL
+      # to skip this prompt.
+      LOGIN_EMAIL="${FALCON_LOGIN_EMAIL:-${GITLAB_USER_EMAIL:-}}"
+      if [ -z "$LOGIN_EMAIL" ]; then
+        printf "%bFalcon login email (the browser opens a fresh session and must sign in).%b\n" "$YELLOW" "$RESET" >&2
+        read -rp "  Enter Falcon login email (or leave blank to log in manually): " LOGIN_EMAIL
+      fi
       FALCON_URL="${FALCON_URL:-https://$( { [ "$CLEANUP_CLOUD" = us-1 ] && echo falcon.crowdstrike.com; } || { [ "$CLEANUP_CLOUD" = eu-1 ] && echo falcon.eu-1.crowdstrike.com; } || echo falcon.us-2.crowdstrike.com )}"
       BROWSER_LOG="$BASE_DIR/verify-browser.log"
 
@@ -524,23 +541,19 @@ if [ "$BROWSER_VERIFY" = "1" ] && [ "$JSON_ONLY" != "1" ]; then
       [ -n "$DEPLOYED_RENDER" ]   && say "  Render-test: $(printf '%s' "$DEPLOYED_RENDER" | tr '\n' ' ')"
       [ -n "$DEPLOYED_ONDEMAND" ] && say "  Execute:     $(printf '%s' "$DEPLOYED_ONDEMAND" | tr '\n' ' ')"
       say "  A browser opens at the Falcon console — log in if prompted."
+      [ -z "$LOGIN_EMAIL" ] && say "${YELLOW}  No login email given — sign in manually in the browser window when it opens (you have 5 minutes).${RESET}"
       say "  Log: $BROWSER_LOG"
 
       BROWSER_PROMPT="You are verifying Falcon Fusion workflows in the CrowdStrike Falcon console.
 
 ## Login
 - Navigate to ${FALCON_URL}/workflow/fusion
-- If a login/SSO page appears, it is passwordless: the email address is already
-  filled in and submitting the form signs you in — no typing and no manual step.
-  Do this: wait 1-2s for the page to settle, take a browser_snapshot, then submit
-  by PRESSING ENTER (the email textbox is already focused). Prefer Enter over
-  clicking the Continue/Log-In button: an Ember glow overlay often intercepts a
-  synthetic button click, whereas pressing Enter on the focused field submits
-  reliably. After Enter, wait 1-2s and snapshot again; SSO redirects through Okta
-  to the 'All workflows' page on its own. If still on a login page, press Enter
-  once more.
-- Only if pressing Enter genuinely does not advance, fall back to polling every
-  15s (up to 3 min) with browser_snapshot until 'All workflows' shows.
+- This is a FRESH browser with no saved session, so an Okta/SSO login page will
+  appear and the email field will be EMPTY (nothing is pre-filled). Do NOT press
+  Enter on an empty field — that does nothing and wastes attempts.
+$( [ -n "$LOGIN_EMAIL" ] && printf -- '- Sign in yourself: take a browser_snapshot, click the email textbox, TYPE\n  '\''%s'\'', then submit by pressing Enter (preferred) or clicking Continue/Log-In.\n  An Ember glow overlay can swallow a synthetic button click, so Enter on the\n  focused field is more reliable. After submitting, wait 2-3s and snapshot again;\n  SSO redirects through Okta to the '\''All workflows'\'' page on its own. If a second\n  email/confirm step appears, repeat.' "$LOGIN_EMAIL" || printf -- '- No email was provided, so a HUMAN will sign in manually in the browser window.\n  Do NOT type, click, or press Enter on the login page. Just WAIT and poll: take a\n  browser_snapshot every 15s for UP TO 5 MINUTES until the URL leaves the login/\n  Okta host and the '\''All workflows'\'' page is visible. The human needs time to type\n  their email and complete SSO — do not give up, do not close the browser, do not\n  report failure while still on a login page before the 5 minutes elapse.' )
+- Once you reach 'All workflows', proceed. If after login you are NOT on the
+  workflows page, navigate to ${FALCON_URL}/workflow/fusion again.
 
 ## Browser guidelines
 - Use browser_snapshot (not screenshots) for element discovery. Wait for page loads between steps.
@@ -636,6 +649,24 @@ if [ "${#DEFERRED_EXEC[@]}" -gt 0 ]; then
       D_NAME="${entry#*|}"; D_NAME="${D_NAME%|*}"
       WORKFLOWS_JSON="$(printf '%s' "$WORKFLOWS_JSON" | jq --arg w "$D_NAME" \
         'map(if .workflow_name == $w then . + {execute: "SKIP", results: "SKIP"} else . end)')"
+      # Step 5 deferred this workflow's cleanup so the (now-skipped) execute
+      # could have found it. The browser phase did not run, so nothing executed,
+      # but --cleanup still means delete it — otherwise it leaks.
+      if [ "$DO_CLEANUP" = "1" ]; then
+        if DEL_OUT="$(delete_workflow "$D_NAME" 2>&1)"; then
+          say "  cleanup:   ${GREEN}PASS${RESET} (deleted '$D_NAME' via API)"
+          WORKFLOWS_JSON="$(printf '%s' "$WORKFLOWS_JSON" | jq --arg w "$D_NAME" \
+            'map(if .workflow_name == $w then . + {cleanup: "PASS"} else . end)')"
+        else
+          DC_ERR="$(printf '%s\n' "$DEL_OUT" | grep -m1 -iE 'ERROR|FAIL' | sed 's/^[[:space:]]*//')"
+          say "  cleanup:   ${RED}FAIL${RESET} ($D_NAME — ${DC_ERR:-API delete failed})"
+          WORKFLOWS_JSON="$(printf '%s' "$WORKFLOWS_JSON" | jq --arg w "$D_NAME" --arg n "${DC_ERR:-}" \
+            'map(if .workflow_name == $w
+                 then . + {cleanup: "FAIL"}
+                      + (if $n == "" then {} else {notes: ((.notes // "") + (if (.notes // "") == "" then "" else "; " end) + "cleanup: " + $n)} end)
+                 else . end)')"
+        fi
+      fi
     done
   else
     say "${BLUE}  Executing ${#DEFERRED_EXEC[@]} credential-gated On-demand workflow(s) via API…${RESET}"
@@ -669,6 +700,27 @@ if [ "${#DEFERRED_EXEC[@]}" -gt 0 ]; then
              then . + {execute: $e, results: $r}
                   + (if $n == "" then {} else {notes: ((.notes // "") + (if (.notes // "") == "" then "" else "; " end) + $n)} end)
              else . end)')"
+
+      # Deferred cleanup: Step 5 left this workflow deployed (C_STATUS=PENDING)
+      # so the execute above could find its definition. Now that the run is done,
+      # honor --cleanup by deleting it via the delete API.
+      if [ "$DO_CLEANUP" = "1" ]; then
+        DC_ERR=""
+        if DEL_OUT="$(delete_workflow "$D_NAME" 2>&1)"; then
+          DC_STATUS="PASS"
+          say "  cleanup:   ${GREEN}PASS${RESET} (deleted '$D_NAME' via API)"
+        else
+          DC_STATUS="FAIL"
+          DC_ERR="$(printf '%s\n' "$DEL_OUT" | grep -m1 -iE 'ERROR|FAIL' | sed 's/^[[:space:]]*//')"
+          say "  cleanup:   ${RED}FAIL${RESET} ($D_NAME — ${DC_ERR:-API delete failed})"
+        fi
+        WORKFLOWS_JSON="$(printf '%s' "$WORKFLOWS_JSON" | jq \
+          --arg w "$D_NAME" --arg c "$DC_STATUS" --arg n "${DC_ERR:-}" \
+          'map(if .workflow_name == $w
+               then . + {cleanup: $c}
+                    + (if $n == "" then {} else {notes: ((.notes // "") + (if (.notes // "") == "" then "" else "; " end) + "cleanup: " + $n)} end)
+               else . end)')"
+      fi
     done
   fi
 fi


### PR DESCRIPTION
Prepares the plugin for the 1.0.0 release and folds in three verified fixes surfaced while validating that release state end-to-end.

**Docs for 1.0.0.** Rewrites the CHANGELOG for a first-release human audience with a hybrid structure (Skills, Validation, Examples, Use Cases, Editor and CLI Support) rather than a refactoring log, and confirms the README and CHANGELOG match the current state of the skills. The README example prompt is now a blockquote for readability, using Paola's approved wording with the Falcon product prefixes (Falcon Fusion, Falcon Next-Gen SIEM). Renames the Gemini CLI references to Antigravity CLI in the prerequisites, install section, and AGENTS.md, and fixes a stale editor-support doc link.

**LLM completion as the email body.** The shipped VirusTotal enrichment example now uses the Charlotte AI completion string directly as the Send email body (`msg: "<html><body>${data['...completion']}</body></html>"`) instead of rebuilding a parallel HTML template inline. Since the model already emits the formatted report, re-templating the same fields is redundant and drifts from the model's output. The http-actions use case documents this pattern so authored workflows follow it.

**Autofill required trigger inputs during verification.** verify-workflows.sh executed deferred On-demand workflows with an empty parameter payload, so a workflow declaring required trigger inputs (for example an enrichment workflow with required `ip` and `notify_email`) was rejected at input validation before any action ran, surfacing as an execute failure that looked like a workflow defect rather than a harness gap. trigger_workflow.py gains a non-interactive `--autofill` mode that reads the deployed definition's trigger parameter schema and fills every required input the caller did not supply, using an `--email` override for email-type fields and name/type heuristics otherwise. Explicit `--params` always win. Adds unit coverage for schema retrieval, per-type value derivation, override precedence, and the CLI path.

The VirusTotal enrichment example was verified live end-to-end against a CID (import, release, on-demand execution): trigger to VirusTotal enrichment to stored variable to Charlotte AI summary to HTML email, all nodes completed. Full suite is green (541 tests) and pylint holds at 10/10.
