### PR TITLE
Point the Falcon Fusion link at the product page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Version](https://img.shields.io/badge/version-1.0.0-blue)
 [![CI](https://github.com/CrowdStrike/fusion-skills/actions/workflows/main.yml/badge.svg)](https://github.com/CrowdStrike/fusion-skills/actions/workflows/main.yml)
 
-AI coding assistant skills for building [CrowdStrike Falcon Fusion](https://www.crowdstrike.com/platform/next-gen-siem/) workflows. Go from a natural language prompt to a working Fusion workflow — discover real action IDs from the live API, author the YAML, validate it against the platform schema, import it to a CID, and trigger and monitor its execution.
+AI coding assistant skills for building [CrowdStrike Falcon Fusion](https://www.crowdstrike.com/en-us/platform/next-gen-siem/falcon-fusion/) workflows. Go from a natural language prompt to a working Fusion workflow — discover real action IDs from the live API, author the YAML, validate it against the platform schema, import it to a CID, and trigger and monitor its execution.
 
 > `fusion-skills` is a community-driven, open source project, not a CrowdStrike product. As such, it carries no formal support, expressed or implied.
 


### PR DESCRIPTION
The intro paragraph linked CrowdStrike Falcon Fusion to the general Next-Gen SIEM page. This points it at the Falcon Fusion product page (https://www.crowdstrike.com/en-us/platform/next-gen-siem/falcon-fusion/) so the link destination matches the link text.