### PR TITLE
Link version badge to GitHub release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Falcon Fusion Skills
 
-![Version](https://img.shields.io/badge/version-1.0.0-blue)
+[![Version](https://img.shields.io/badge/version-1.0.0-blue)](https://github.com/CrowdStrike/fusion-skills/releases/tag/v1.0.0)
 [![CI](https://github.com/CrowdStrike/fusion-skills/actions/workflows/main.yml/badge.svg)](https://github.com/CrowdStrike/fusion-skills/actions/workflows/main.yml)
 
 AI coding assistant skills for building [CrowdStrike Falcon Fusion](https://www.crowdstrike.com/en-us/platform/next-gen-siem/falcon-fusion/) workflows. Go from a natural language prompt to a working Fusion workflow — discover real action IDs from the live API, author the YAML, validate it against the platform schema, import it to a CID, and trigger and monitor its execution.

--- a/release.sh
+++ b/release.sh
@@ -162,6 +162,9 @@ main() {
   # Use portable sed with temp file pattern (macOS and Linux compatible)
   sed 's/badge\/version-[0-9.]*-blue/badge\/version-'"$NEXT_VERSION"'-blue/' "$SCRIPT_DIR/README.md" > /tmp/README.md.tmp
   mv /tmp/README.md.tmp "$SCRIPT_DIR/README.md"
+  # Update the badge release link target
+  sed 's|releases/tag/v[0-9.]*|releases/tag/v'"$NEXT_VERSION"'|' "$SCRIPT_DIR/README.md" > /tmp/README.md.tmp
+  mv /tmp/README.md.tmp "$SCRIPT_DIR/README.md"
   printf "${GREEN}✓${RESET} README badge → v${NEXT_VERSION}\n"
 
   printf "\n${BLUE}Step 3: Update SKILL.md versions${RESET}\n"


### PR DESCRIPTION
The version badge was a plain image with no link. Now it links to the release page, and release.sh updates the link on each release.