### PR TITLE
Name the deployment skill consistently with its siblings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.0.1] - TBD
+
+### Fixed
+
+- Relocated helper scripts from `bin/` to `scripts/` so the plugin installs on claude.ai and Cowork. A top-level `bin/` directory is added to the CLI's PATH but isn't shown on the web admin approval surface, so those hosts rejected the plugin. The scripts are internal helpers, not entry points, and moving them out of `bin/` clears the block. Command-line installs were unaffected.
+
+### Changed
+
+- Renamed the deployment skill from `deploy` to `deployment` so it matches its sibling skills (`authoring`, `execution`) and the `foundry-skills` convention. The command is now `/crowdstrike-falcon-fusion:deployment`; the picker no longer rewrites `:deploy` to `:deployment` on submit.
+- The README version badge now links to the matching GitHub release.
+
 ## [1.0.0] - 2026-07-30
 
 First public release of Falcon Fusion Skills — AI coding assistant skills for building CrowdStrike Falcon Fusion workflows. Describe the automation you want in plain language and your assistant discovers the real action IDs from your tenant, writes the YAML, validates it against the platform schema, imports it to your CID, and runs it.
@@ -33,4 +44,5 @@ First public release of Falcon Fusion Skills — AI coding assistant skills for 
 
 - Tested with Claude Code. Experimental setup instructions for Codex, Copilot CLI, Cursor, and Antigravity CLI, written from each tool's own documentation but not yet verified end to end. The skills are plain markdown, so any assistant that reads local files can use them.
 
+[1.0.1]: https://github.com/CrowdStrike/fusion-skills/releases/tag/v1.0.1
 [1.0.0]: https://github.com/CrowdStrike/fusion-skills/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Changed
 
 - Renamed the deployment skill from `deploy` to `deployment` so it matches its sibling skills (`authoring`, `execution`) and the `foundry-skills` convention. The command is now `/crowdstrike-falcon-fusion:deployment`; the picker no longer rewrites `:deploy` to `:deployment` on submit.
-- The README version badge now links to the matching GitHub release.
 
 ## [1.0.0] - 2026-07-30
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The skills include hooks that ensure the right skills get used:
 
 3. **`PreToolUse` hook (cross-plugin bridge)** — Advisory only. If a request needs a Foundry app (UI, functions, collections, `manifest.yml`), it suggests the sibling [`crowdstrike-falcon-foundry`](https://github.com/CrowdStrike/foundry-skills) plugin. It never blocks a skill.
 
-The `workflows` orchestrator is the entry point: you say what you want, and it routes to `authoring` (discover actions, write and validate YAML), `deploy` (import and release to a CID), and `execution` (trigger and monitor). Hooks observe prompts and tool I/O to keyword-match Fusion actions; no data leaves the session.
+The `workflows` orchestrator is the entry point: you say what you want, and it routes to `authoring` (discover actions, write and validate YAML), `deployment` (import and release to a CID), and `execution` (trigger and monitor). Hooks observe prompts and tool I/O to keyword-match Fusion actions; no data leaves the session.
 
 ## Skills
 
@@ -161,7 +161,7 @@ One plugin provides five skills: an orchestrator plus four focused sub-skills.
 |-------|---------|
 | `workflows` | Primary orchestrator — routes intent and coordinates the full workflow lifecycle |
 | `authoring` | Action discovery (`action_search.py`), YAML authoring, CEL expressions, schema validation (`validate.py`) |
-| `deploy` | Duplicate check, import to CID, release, version management |
+| `deployment` | Duplicate check, import to CID, release, version management |
 | `execution` | Trigger workflows with payloads, monitor status, tail logs, debug failures |
 | `lookup-files` | Manage Falcon Next-Gen SIEM lookup files (CSV/JSON/TXT) for CQL `match()` queries |
 
@@ -185,7 +185,7 @@ graph TD
     style LF fill:#f59e0b,stroke:#d97706,color:#fff
 ```
 
-A typical lifecycle: `authoring` produces a validated YAML file → `deploy` imports it and returns a `definition_id` → `execution` triggers it and returns an `execution_id`. Each phase depends on the previous one's output.
+A typical lifecycle: `authoring` produces a validated YAML file → `deployment` imports it and returns a `definition_id` → `execution` triggers it and returns an `execution_id`. Each phase depends on the previous one's output.
 
 ```
 skills/

--- a/skills/deployment/SKILL.md
+++ b/skills/deployment/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: deploy
+name: deployment
 description: >
   Import, release, and manage Falcon Fusion workflow definitions in a CID.
   TRIGGER when user asks to import a workflow, release a workflow version,

--- a/skills/deployment/references/console-verification.md
+++ b/skills/deployment/references/console-verification.md
@@ -34,7 +34,7 @@ that, and how to navigate the console reliably to do it.
    followed by a blank/partial canvas (0 nodes drawn, Test/Save/Publish locked).
    A clean render draws the full graph with **zero** console errors.
 4. Delete the test workflow afterward with `delete_workflow.py --id <hex>` (see
-   the deploy skill) so it doesn't linger in the CID.
+   the deployment skill) so it doesn't linger in the CID.
 
 The crash above is caused by referencing a node the canvas can't build — most
 often a synthetic gateway pass-through. See `workflows/references/yaml-schema.md`

--- a/skills/execution/SKILL.md
+++ b/skills/execution/SKILL.md
@@ -5,7 +5,7 @@ description: >
   TRIGGER when user asks to run a workflow, check execution status, tail logs,
   get execution results, or debug a workflow failure.
   DO NOT TRIGGER for writing YAML (use authoring) or importing/releasing
-  workflows (use deploy).
+  workflows (use deployment).
 version: 1.0.0
 updated: 2026-06-26
 tags: [fusion, soar, workflows, execution, monitoring, debugging]
@@ -49,7 +49,7 @@ An execution moves through states and ends in a **terminal** state. The terminal
 
   Run `/crowdstrike-falcon-fusion:setup` to configure credentials interactively (writes the TOML profile).
 - An API client with the **Workflow** API scope
-- The **definition ID** of the workflow to run (from the deploy skill's import output, or `query_workflows.py --search`)
+- The **definition ID** of the workflow to run (from the deployment skill's import output, or `query_workflows.py --search`)
 - Verify auth before running:
   ```bash
   ${CLAUDE_PLUGIN_ROOT}/scripts/python.sh common/scripts/auth.py
@@ -65,7 +65,7 @@ A workflow must be enabled before it will execute. Confirm it exists and is enab
 ${CLAUDE_PLUGIN_ROOT}/scripts/python.sh deployment/scripts/query_workflows.py --search "my workflow"
 ```
 
-Look for `Status: enabled` in the output. If it shows `disabled`, release it first with the deploy skill (`release_workflow.py --id <id>`).
+Look for `Status: enabled` in the output. If it shows `disabled`, release it first with the deployment skill (`release_workflow.py --id <id>`).
 
 ### 2. Trigger the workflow with a payload
 
@@ -155,7 +155,7 @@ Single fetch. Reads `resources[0]` from the API envelope for the execution's `st
 
 ## Common Pitfalls
 
-1. **Triggering an unreleased workflow.** A disabled definition will not execute. Confirm `Status: enabled` (step 1) before triggering, and release it via the deploy skill if needed.
+1. **Triggering an unreleased workflow.** A disabled definition will not execute. Confirm `Status: enabled` (step 1) before triggering, and release it via the deployment skill if needed.
 
 2. **Missing required parameters.** When triggered via API (not the console UI), parameters are not prompted by the platform. Pass every required field in `--params`. Empty params are the most common failure cause.
 

--- a/skills/lookup-files/SKILL.md
+++ b/skills/lookup-files/SKILL.md
@@ -5,7 +5,7 @@ description: >
   TRIGGER when user asks to create, list, update, or delete lookup files,
   or needs help with CQL match() function.
   DO NOT TRIGGER for Fusion workflows, action discovery, or workflow deployment —
-  use the workflows/authoring/deploy skills.
+  use the workflows/authoring/deployment skills.
 version: 1.0.0
 updated: 2026-06-26
 tags: [falcon, ngsiem, siem, lookup-files, cql, threat-hunting]

--- a/skills/workflows/SKILL.md
+++ b/skills/workflows/SKILL.md
@@ -50,7 +50,7 @@ so route based on these criteria without loading sub-skills first.
 User wants to write/edit workflow YAML            → invoke authoring skill
 User wants to find/discover actions               → invoke authoring skill
 User wants to validate a workflow                 → invoke authoring skill
-User wants to deploy/import/release a workflow     → invoke deploy skill
+User wants to deploy/import/release a workflow     → invoke deployment skill
 User wants to run/monitor/debug a workflow         → invoke execution skill
 User wants full lifecycle (create + deploy + test) → coordinate all three in sequence
 User mentions a Foundry app / manifest.yml         → advise foundry-skills (see below)
@@ -62,7 +62,7 @@ User mentions lookup files / Next-Gen SIEM         → invoke lookup-files skill
 | Intent keyword | Sub-skill | What it owns |
 |----------------|-----------|--------------|
 | "write", "edit", "author", "discover actions", "validate" | **authoring** | Action discovery (`action_search.py`), YAML authoring, CEL, validation (`validate.py`) |
-| "deploy", "import", "release", "publish to CID" | **deploy** | Duplicate check, import, release, version management |
+| "deploy", "import", "release", "publish to CID" | **deployment** | Duplicate check, import, release, version management |
 | "run", "execute", "trigger", "monitor", "tail", "debug" | **execution** | Triggering with payloads, monitoring, logs, results |
 | "lookup file", "CSV/JSON lookup", "match() query" | **lookup-files** | Next-Gen SIEM lookup file management |
 | "Foundry app", "manifest", "UI + workflow", "functions" | **foundry-skills** (sibling plugin) | App lifecycle, manifest coordination |
@@ -77,7 +77,7 @@ coordinate the three sub-skills in sequence. Do not skip phases.
 2. Write the workflow YAML against the schema, with `version_constraint` on every action.
 3. Validate with `validate.py` (structural) and, if credentials exist, API validation.
 
-**Step 2 — Deployment** (invoke deploy skill)
+**Step 2 — Deployment** (invoke deployment skill)
 1. Check for an existing workflow of the same name (`query_workflows.py`) — avoid silent duplicate versions.
 2. Import the validated YAML to the CID (`import_workflows.py`).
 3. Release the workflow so it becomes executable (`release_workflow.py`).
@@ -114,8 +114,8 @@ User: "Create a Fusion workflow that contains a host on critical detection, then
 
 **After authoring + validating, offer to deploy — don't print a command.** When the user asked to
 build a workflow (not "just write the YAML"), and it validates, ASK "Deploy this to your CID now?"
-and, on yes, run the deploy yourself via the `deploy` skill. Never tell the user to paste
-`/crowdstrike-falcon-fusion:deploy` — invoke it for them. If the workflow contains a
+and, on yes, run the deploy yourself via the `deployment` skill. Never tell the user to paste
+`/crowdstrike-falcon-fusion:deployment` — invoke it for them. If the workflow contains a
 credential-less HTTP Action, after a successful import tell the user it imported (disabled until
 released) and give the console steps to attach the API key: open the Cloud HTTP Request action →
 Authentication → Create new → API key → secret key → location Header → header name (e.g.


### PR DESCRIPTION
**This is not a bug fix.** The current setup works: the skill lives in `skills/deployment/` and declares `name: deploy`, and it resolves and loads correctly either way. This is a naming consistency cleanup, safe to defer or decline.

`deploy` was the only imperative verb among six otherwise nominal skill names:

| Skill | Form |
|-------|------|
| `authoring` | gerund |
| `deploy` | imperative verb |
| `execution` | noun |
| `lookup-files` | noun |
| `setup` | noun |
| `workflows` | noun |

`authoring` / `deployment` / `execution` reads as a consistent trio; `author` / `deploy` / `execute` would too. Mixing one member of the second set into the first is the inconsistency. Nominal naming is also what `foundry-skills` uses across all ten of its skills.

There is a small side benefit: the command picker offered `/crowdstrike-falcon-fusion:deploy` (from the frontmatter) but rewrote it to `:deployment` (from the directory) on submit. With both set to `deployment`, there is nothing to rewrite.

## Approach

Changed the frontmatter to `name: deployment` rather than renaming the directory to `deploy`. The frontmatter route is 15 lines across 6 files; the directory rename would have touched 21 path references across 8 files including CI config, for the same result.

Also updates the 12 places that named the skill `deploy`: the README skill table and lifecycle prose, the orchestrator's intent-routing table and handoff instructions, and cross-references in `execution`, `lookup-files`, and `console-verification.md`. (`authoring` already said "deployment.")

Prose using "deploy" as an ordinary verb is left alone.

## Verification

- `./test-validate.sh` — 56 passed, 0 failed
- `./test-hooks.sh` — 14 passed, 0 failed

## Stacking

Targets `fix/bin-to-scripts` (#18) rather than `main`, since #18 modifies four of the same SKILL.md files. GitHub will retarget this to `main` automatically once #18 merges.