### PR TITLE
Add US-3 region support to credential setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.1.0] - TBD
+
+### Added
+
+- US-3 cloud region to credential setup: a `[us-3]` profile example (`https://api.us-3.crowdstrike.com`) in the setup skill's multi-cloud block and in the README region notes, alongside a `[us-gov-1]` example that was also missing. The auth module already accepts any `base_url`, so this documents the host rather than changing behavior.
+
 ## [1.0.1] - 2026-08-07
 
 ### Fixed
@@ -43,5 +49,6 @@ First public release of Falcon Fusion Skills — AI coding assistant skills for 
 
 - Tested with Claude Code. Experimental setup instructions for Codex, Copilot CLI, Cursor, and Antigravity CLI, written from each tool's own documentation but not yet verified end to end. The skills are plain markdown, so any assistant that reads local files can use them.
 
+[1.1.0]: https://github.com/CrowdStrike/fusion-skills/releases/tag/v1.1.0
 [1.0.1]: https://github.com/CrowdStrike/fusion-skills/releases/tag/v1.0.1
 [1.0.0]: https://github.com/CrowdStrike/fusion-skills/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ For CI or a one-off override, set environment variables instead:
 export FALCON_CLIENT_ID=your_client_id_here
 export FALCON_CLIENT_SECRET=your_client_secret_here
 # export FALCON_BASE_URL=https://api.crowdstrike.com  # US-1 (default)
+# US-2: https://api.us-2.crowdstrike.com · US-3: https://api.us-3.crowdstrike.com · EU-1: https://api.eu-1.crowdstrike.com · US-GOV-1: https://api.laggar.gcw.crowdstrike.com
 ```
 
 Credentials come from environment variables (checked first) or the TOML profile, and are never hardcoded. Verify your setup:
@@ -269,7 +270,7 @@ python common/scripts/auth.py          # Verify credentials resolve and a token 
 /crowdstrike-falcon-fusion:setup        # Re-run interactive credential setup (Claude Code)
 ```
 
-Confirm `FALCON_CLIENT_ID` and `FALCON_CLIENT_SECRET` are set in your environment or TOML profile, and that `FALCON_BASE_URL` points at the correct cloud (US-1 is the default; set it for US-2, EU-1, or US-GOV).
+Confirm `FALCON_CLIENT_ID` and `FALCON_CLIENT_SECRET` are set in your environment or TOML profile, and that `FALCON_BASE_URL` points at the correct cloud (US-1 is the default; set it for US-2, US-3, EU-1, or US-GOV).
 
 ### Stale action cache
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -93,10 +93,20 @@ base_url = "https://api.us-2.crowdstrike.com"
 # client_secret = ""
 # base_url = "https://api.crowdstrike.com"
 #
+# [us-3]
+# client_id = ""
+# client_secret = ""
+# base_url = "https://api.us-3.crowdstrike.com"
+#
 # [eu-1]
 # client_id = ""
 # client_secret = ""
 # base_url = "https://api.eu-1.crowdstrike.com"
+#
+# [us-gov-1]
+# client_id = ""
+# client_secret = ""
+# base_url = "https://api.laggar.gcw.crowdstrike.com"
 ```
 
 After creating the file, restrict its permissions (skip on Windows, where the user


### PR DESCRIPTION
Documents the US-3 cloud in credential setup. The shared auth module already accepts any `base_url` (from `FALCON_BASE_URL` or a TOML profile), so US-3 works mechanically today — this makes the host discoverable rather than leaving users to guess it.

Changes:
- `skills/setup/SKILL.md` — added a `[us-3]` profile example (`https://api.us-3.crowdstrike.com`) to the multi-cloud TOML block, plus a `[us-gov-1]` example that was also missing.
- `README.md` — added US-3 (and US-GOV-1) to the `FALCON_BASE_URL` region notes.

Base URLs match the FalconPy `BaseURL` enum. No code changes — auth is already region-agnostic.

Draft while US-3 completes its rollout.