### PR TITLE
Fix run-ab-test.sh cleanup crash on macOS sed

### DIFF
--- a/run-ab-test.sh
+++ b/run-ab-test.sh
@@ -109,7 +109,12 @@ cleanup_phase_workflows() {
     local wf_file wf_name
     wf_file=$(find_workflow_file "$dir")
     [ -n "$wf_file" ] || continue
-    wf_name=$(grep -m1 -E '^name:' "$wf_file" 2>/dev/null | sed -E "s/^name:[[:space:]]*['\"]?(.+?)['\"]?[[:space:]]*$/\1/")
+    # Strip the "name:" prefix and any surrounding quotes. Uses three simple
+    # substitutions rather than one lazy-quantified capture group, because BSD
+    # (macOS) sed rejects the '.+?' non-greedy operator with "RE error:
+    # repetition-operator operand invalid".
+    wf_name=$(grep -m1 -E '^name:' "$wf_file" 2>/dev/null \
+      | sed -E "s/^name:[[:space:]]*//; s/^[\"']//; s/[\"'][[:space:]]*$//")
     [ -n "$wf_name" ] && names+=("$wf_name")
   done
 


### PR DESCRIPTION
`run-ab-test.sh` aborted mid-run during RED-phase cleanup on macOS with:

```
sed: 1: "s/^name:[[:space:]]*['" ...": RE error: repetition-operator operand invalid
```

The workflow-name extraction in `cleanup_phase_workflows` used a lazy quantifier (`.+?`) inside a `sed -E` capture group. BSD sed (the default on macOS) doesn't support `?` as a non-greedy operator and rejects the expression. Because the extraction runs in a command substitution under `set -euo pipefail`, the failure took down the entire A/B run after the RED baseline was saved but before the GREEN phase started, so no comparison ever ran.

This replaces the single capture-group substitution with three portable substitutions that strip the `name:` prefix and any surrounding quotes. Verified on both BSD and GNU sed against real generated workflow names, including a bracketed `[run-2]` suffix that a naive strip would mangle.

No behavior change beyond the fix; the extracted names are identical on GNU sed, where the original already worked.
