### PR TITLE
Add Deduplicate and Rate Limit action reference and example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - US-3 cloud region to credential setup: a `[us-3]` profile example (`https://api.us-3.crowdstrike.com`) in the setup skill's multi-cloud block and in the README region notes, alongside a `[us-gov-1]` example that was also missing. The auth module already accepts any `base_url`, so this documents the host rather than changing behavior.
 - Throttling reference in the execution skill: explains that a workflow stuck "in progress" may be throttled (Fusion paces an action past a volume limit, auto-retrying up to 6 hours) rather than failed, how to recognize it on the execution detail view, and when sustained throttling signals a workflow-design issue.
+- Deduplicate and Rate Limit action reference plus a worked tutorial example. Covers all six Deduplicate activities and all four Rate Limit activities: the `definition`/`cid` scope values (which the console labels "Workflow" and "CID"), the atomic claim, metadata handoff, and the save-time validation the builder runs. The example deduplicates third-party NG-SIEM detections into a single case. Action IDs were confirmed against a live tenant; the example passes validation at all tiers.
 
 ## [1.0.1] - 2026-08-07
 

--- a/skills/authoring/SKILL.md
+++ b/skills/authoring/SKILL.md
@@ -53,7 +53,7 @@ metadata:
 > only for actions the table does not cover.
 > 3. Run `trigger_search.py` to confirm the trigger type.
 > 4. Run `validate.py` on every YAML file before presenting it.
-> 5. **Re-run `validate.py` on the FINAL file; resolve every ERROR before finishing.** A file that still errors is not done. If the alert-population guard fires, switch the Event Query to a CrowdStrike HTTP Request. Never hand off a file that fails validation.
+> 5. **Re-run `validate.py` on the FINAL file; resolve every ERROR before finishing.** A file that still errors is not done. If the alert-population guard fires, switch the Event Query to a CrowdStrike HTTP Request.
 >
 > **MUST NOT:**
 > - Author a workflow for a Foundry-app-shaped request (see action 0) — redirect to foundry-skills.
@@ -253,7 +253,7 @@ force an immediate refresh so newly shipped action types are never hidden.
 | "The template has `PLACEHOLDER_RAN_006`, I'll copy it." | NEVER. Templates are structural guides. Substitute a real value before saving. |
 | "Validation can wait until deploy." | NO. Validate after authoring — `validate.py` catches PLACEHOLDERs, bad IDs, and schema errors locally. |
 | "This action has a `class`, version_constraint is optional." | WRONG. Class-based actions REQUIRE `version_constraint`. Missing it fails import. |
-| "I'll use `~1` everywhere for version_constraint." | NO. The value is `~<major>` of the action's `semantic_version` (`~0` when it declares none): `1.0.4` → `~1`, `0.0.100` (Charlotte AI, most Store plugins) → `~0`. Read it from `--details`. |
+| "I'll use `~1` everywhere for version_constraint." | NO. The value is `~<major>` of the action's `semantic_version` (`~0` when it declares none): `1.0.4` → `~1`, `0.0.100` → `~0`. Read it from `--details`. |
 | "I'll make up a `config_id` for this Okta action." | NEVER. It's CID-specific (exists only once configured in the console). Ask the user (AskUserQuestion) — even non-interactively. Sequential/all-zeros/repeated-char UUIDs are still fabricated and fail at runtime; can't get a real one? STOP. See `references/best-practices.md`. |
 | "I'll set `definition_id: VIRUSTOTAL_..._ID` on this HTTP action." | NEVER. An `Inline.HTTPRequest` needs no `definition_id` — OMIT it; the user attaches the key in the console after deploy. A placeholder is a broken ref `validate.py` flags. |
 | "The Send email field is called Recipients, so I'll use `recipients:`." | WRONG. The property KEY is `to:` (a list); `recipients:` is rejected. Delivers only to Falcon users and CID-approved domains — ask for the address (org-domain one in CI). |
@@ -282,6 +282,7 @@ the task actually calls for them:
 | Run a CQL/FQL event query in a step — inputs, outputs | `references/event-query-action.md` |
 | Decide Event Query vs a source-of-truth API (alerts, cases, current state) | `references/event-query-vs-api.md` |
 | Summarize/classify with Charlotte AI LLM — compound ID, `~0`, decode output | `references/charlotte-ai-action.md` |
+| Deduplicate or rate-limit a workflow — scopes, keys | `references/deduplicate-ratelimit.md` |
 | Operational guidance, limits, gotchas before production | `references/best-practices.md` |
 
 **Advanced (rarely needed):**

--- a/skills/authoring/examples/README.md
+++ b/skills/authoring/examples/README.md
@@ -14,7 +14,7 @@ network containment, notifications, and more.
 | `notifications/` | 2 | Alert routing, Slack notifications, and human-approved endpoint containment. |
 | `ngsiem/` | 1 | Falcon Next-Gen SIEM duplicate-detection management. |
 | `response-actions/` | 6 | Palo Alto Networks NGFW integration for network-level response (DAG tags, EDLs). |
-| `tutorials/` | 8 | "Introduction to..." playbooks teaching specific Fusion concepts. |
+| `tutorials/` | 9 | "Introduction to..." playbooks teaching specific Fusion concepts. |
 
 ## Workflows
 
@@ -59,6 +59,7 @@ network containment, notifications, and more.
 - [Introduction to the Python script action: build a lookup file from an external feed](tutorials/intro-python-sslbl-lookup.yaml) — an `Inline.Python` action fetches and reshapes the abuse.ch SSL blocklist, and its `output_stdout` feeds a lookup file
 - [Introduction to Receive Email trigger: How to create a lookup file from an email attachment](tutorials/intro-receive-email-trigger.yaml)
 - [Introduction to variables: How to append to an array](tutorials/intro-variables-append-array.yaml)
+- [Introduction to deduplication: How to deduplicate third-party detections](tutorials/intro-deduplicate-third-party-detections.yaml) — the **Deduplicate** action family suppresses duplicate NG-SIEM third-party (Palo Alto) detections: a sha1 key over a 24h window creates one case and comments duplicates onto it. See `references/deduplicate-ratelimit.md`. **Pre-GA** — action IDs are from a console export, not yet live-verified in our tenant
 - [CrowdStrike HTTP Request: query the Falcon Alerts API and email the result](tutorials/crowdstrike-http-request-falcon-api.yaml) — the canonical **CrowdStrike HTTP Request** shape (Falcon platform API, distinct from a Cloud HTTP Request): absolute region host, query params in `request_query` (not the URL), required OAuth credential (`UseExisting` + `config_id`). Built and executed live end-to-end.
 
 ## How to use these examples

--- a/skills/authoring/examples/tutorials/intro-deduplicate-third-party-detections.yaml
+++ b/skills/authoring/examples/tutorials/intro-deduplicate-third-party-detections.yaml
@@ -1,0 +1,103 @@
+# Source: CrowdStrike-authored tutorial workflow "Introduction to
+# deduplication: How to Deduplicate Third Party Detections", exported from the
+# Falcon console. Demonstrates the Deduplicate action family suppressing
+# duplicate third-party (Palo Alto) NG-SIEM detections into a single case.
+#
+# Availability: The Deduplicate and Rate Limit actions are enabled in all
+# commercial CIDs, and are available in US-1, US-2, and EU-1 by default (other
+# environments by request). The action IDs and version_constraints below were
+# confirmed against a live tenant with action_search.py, and this file passes
+# validate.py at all tiers, including server-side API validation.
+#
+# Pattern: NG-SIEM third-party detection (Palo Alto) -> Deduplicate on a sha1 key
+# built from detection type + source/dest IPs, 24h window -> if new, create a
+# case and record its ID as the entry's metadata -> if duplicate, wait for that
+# metadata and comment on the original case. See
+# references/deduplicate-ratelimit.md.
+# This is an exported workflow. Editing this file is not recommended.
+
+name: 'Introduction to deduplication: How to Deduplicate Third Party Detections'
+description: Learn how to leverage the deduplication action to deduplicate third party detections from Palo Alto Networks
+disconnected_nodes:
+    - '{"id":"notes_b5eee5d5-1646-4562-9e25-f933d06a9ed0","position":{"x":304.24687139282736,"y":526.301954879066},"node_type":"notes","comment":"Dedups for a period of one day"}'
+trigger:
+    next:
+        - data39trigger_detection_thirdparty_sourcevendors39_existsone__v_v__34paloalto34
+    event: Investigatable/THIRDPARTY
+    name: Detection > NG-SIEM Third Party Detection
+    type: Signal
+    version_constraint: ~1
+actions:
+    AddCommentToCase:
+        id: a16f4fdd1b244b0bfeecd47e25dbe0e0
+        default_name: Add Comment to Case
+        name: Add Comment to Case
+        properties:
+            case_id: ${data['WaitForDeduplicateEntryMetadata.metadata']}
+            comment: 'Detection ID: ${data[''Trigger.Detection.DetectionID'']} is a duplicate.'
+        version_constraint: ~1
+    CreateANewCase:
+        id: 4918bf9d85ecc06388eca16543bdbbdc
+        default_name: Create a new Case
+        name: Create a new Case
+        next:
+            - SetDeduplicateEntryMetadata
+        properties:
+            description: |-
+                Name: ${data['Trigger.Detection.Name']}
+                Description: ${data['Trigger.Detection.Description']}
+            detections:
+                - ${Trigger.Detection.DetectionID}
+            name: Detection ${data['Trigger.Detection.Name']}
+            severity_level: 3
+            status: new
+        version_constraint: ~1
+    Deduplicate:
+        id: f6f68f316170550b2777aec3dc3c85e1
+        default_name: Deduplicate
+        name: Deduplicate
+        next:
+            - duplicate_is_equal_to_false
+        properties:
+            key: |-
+                ${cs.hash.sha1(data['Trigger.Detection.ThirdParty.DetectionType'] +
+                data['Trigger.Detection.ThirdParty.SourceIPs'].join(",") +
+                data['Trigger.Detection.ThirdParty.DestinationIPs'].join(","))}
+            period: 86400
+            scope: definition
+        version_constraint: ~2
+    SetDeduplicateEntryMetadata:
+        id: 7cd6f7bde9eef6a98d851d8270e4f1f4
+        default_name: Set Deduplicate Entry Metadata
+        name: Set Deduplicate Entry Metadata
+        properties:
+            key: ${data['Deduplicate.key']}
+            metadata: ${data['CreateANewCase.id']}
+            scope: definition
+        version_constraint: ~1
+    WaitForDeduplicateEntryMetadata:
+        id: 7bddab2fa0d5c5c90fdb49e0f3eef380
+        default_name: Wait for Deduplicate Entry Metadata
+        name: Wait for Deduplicate Entry Metadata
+        next:
+            - AddCommentToCase
+        properties:
+            key: ${data['Deduplicate.key']}
+            scope: definition
+        version_constraint: ~1
+conditions:
+    data39trigger_detection_thirdparty_sourcevendors39_existsone__v_v__34paloalto34:
+        next:
+            - Deduplicate
+        cel_expression: data['Trigger.Detection.ThirdParty.SourceVendors'].existsOne(_, v, v == "Paloalto")
+        display:
+            - data[&#39;Trigger.Detection.ThirdParty.SourceVendors&#39;].existsOne(_, v, v == &#34;Paloalto&#34;)
+        name: If Vendor is Palo Alto
+    duplicate_is_equal_to_false:
+        next:
+            - CreateANewCase
+        expression: Deduplicate.duplicate:false
+        display:
+            - Duplicate is equal to False
+        else:
+            - WaitForDeduplicateEntryMetadata

--- a/skills/authoring/references/deduplicate-ratelimit.md
+++ b/skills/authoring/references/deduplicate-ratelimit.md
@@ -1,0 +1,237 @@
+# Deduplicate & Rate Limit actions
+
+Two families of built-in coordination actions that give workflows shared,
+distributed state. **Deduplicate** answers "have I already handled this?"
+(atomic once-only claim on a key). **Rate Limit** answers "am I going too fast?"
+(pace a workflow against a shared budget). Both are inline actions — no Foundry
+app, no `config_id`, no credential.
+
+> **Availability.** These actions are enabled in all commercial CIDs, available
+> in US-1, US-2, and EU-1 by default (other environments by request). As always,
+> resolve the real action IDs and `version_constraint` values from your own tenant
+> with `action_search.py --search "deduplicate"` / `"rate limit"` rather than
+> hardcoding — the IDs in the worked example
+> (`examples/tutorials/intro-deduplicate-third-party-detections.yaml`) were
+> confirmed against a live tenant.
+
+## The scope gotcha (read this first)
+
+The console labels the two scopes **Workflow** and **CID**. The value the
+platform stores in YAML is **not** `workflow` — it is `definition`:
+
+```yaml
+properties:
+    scope: definition   # console label: "Workflow" (the default, per-definition)
+    # scope: cid        # console label: "CID" (tenant-wide, shared across workflows)
+```
+
+Author `scope: definition` for per-workflow suppression (the default and almost
+always what you want) and `scope: cid` only when several different workflows must
+share one window. Writing `scope: workflow` from the console label does not match
+what the platform accepts.
+
+## Keys (both families)
+
+The key is the identity of the thing you are coordinating on. Same rules for
+Deduplicate and Rate Limit:
+
+- Required, at most **150 characters**.
+- Allowed characters: letters, digits, `_`, `-`. No dots, colons, spaces,
+  slashes, or `@`.
+- Both rules apply to the key's **final value after CEL expressions are
+  evaluated**, not to what you type. A 200-char expression that resolves to a
+  40-char string is fine.
+- **Validation happens at execution, not save.** A key that resolves to something
+  too long or with bad characters saves cleanly and fails at run time.
+
+Because of the character rule, hash any key built from multiple fields or from
+values you do not control:
+
+```yaml
+key: |-
+    ${cs.hash.sha1(data['Trigger.Detection.ThirdParty.DetectionType'] +
+    data['Trigger.Detection.ThirdParty.SourceIPs'].join(",") +
+    data['Trigger.Detection.ThirdParty.DestinationIPs'].join(","))}
+```
+
+`cs.hash.sha1` turns any input into a fixed-length string that always satisfies
+both rules. This is the recommended approach for composite keys.
+
+---
+
+## Deduplicate family
+
+A "have I already handled this?" primitive. **Deduplicate** is atomic: if two
+executions race on the same key, exactly one is told it is the original
+(`duplicate: false`) and every other is told it is a duplicate (`duplicate:
+true`). There is no window where both think they are first.
+
+Six actions:
+
+| Action | What it does |
+|--------|--------------|
+| **Deduplicate** | Claims a key for `period` seconds. Tells you whether it was already claimed. |
+| **View Deduplicate Entry** | Checks whether a key is claimed, without claiming it. |
+| **Delete Deduplicate Entry** | Releases a key early, before its period expires. |
+| **View All Deduplicate Entries** | Lists every entry in a scope, plus quota usage. |
+| **Set Deduplicate Entry Metadata** | Attaches a note (e.g. a case ID) to an existing entry. |
+| **Wait for Deduplicate Entry Metadata** | Waits for another execution to attach that note. |
+
+### Deduplicate
+
+Attempts to claim `scope` + `key` for `period` seconds. If nothing held the key,
+this execution claims it and `duplicate` is `false`. If the key was already held,
+nothing changes (the original period is **not** extended) and `duplicate` is
+`true`.
+
+Inputs: `scope` (required, `definition`/`cid`, default `definition`), `key`
+(required), `period` (required, seconds; `0` = never expires).
+
+Outputs: `key` (evaluated value — reference this downstream instead of repeating
+the expression), `duplicate`, `originating_execution_id`, `metadata` (only when
+`duplicate: true` and metadata was set), `period_remaining`, `expires_at`.
+
+**How to use it:** put Deduplicate right after the trigger, then branch on
+`duplicate`:
+
+- `duplicate == false` → do the real work (create the case, page the analyst).
+- `duplicate == true` → end, or take a cheap path like commenting on the
+  existing case.
+
+The period is fixed at creation — repeated hits do not slide the window forward,
+so the entry always expires a set time after the *first* event. Common periods:
+`3600` (one per hour), `86400` (one per day), `0` (once forever — consumes quota
+until deleted).
+
+### View / Delete / View All
+
+- **View Deduplicate Entry** — reads state without claiming. Returns `exists`,
+  and when it exists `metadata` / `period_remaining` / `expires_at`. Viewing a
+  missing entry is not an error (`exists: false`).
+- **Delete Deduplicate Entry** — removes an entry early so the key can be claimed
+  again. Returns `deleted`. Use to re-arm after a case is resolved, to undo on
+  failure (so the next event retries instead of being suppressed), or to free
+  quota held by `period: 0` entries.
+- **View All Deduplicate Entries** — lists `{key, period_remaining, expires_at}`
+  per entry plus `quota.limit`/`used`/`remaining`. Does **not** include metadata;
+  use View for a specific key to read that.
+
+> **View is not race-safe.** "View, then act" has a gap between the check and the
+> work. To do something once, use **Deduplicate** and branch on `duplicate` —
+> that is the atomic path. View is for reporting and diagnostics.
+
+### Set / Wait for Metadata
+
+The classic pattern: the original execution claims `detection_123`, creates case
+`CS-4711`, and records `CS-4711` as the entry's metadata. Every suppressed
+duplicate can then say *which* case already covers it.
+
+- **Set Deduplicate Entry Metadata** — attaches a note (1–250 chars) to an
+  existing entry. **It only updates; it never creates** and never changes expiry.
+  Place it after a Deduplicate on the non-duplicate branch; if the entry expired
+  or was never claimed, `updated` is `false` and the note is silently dropped.
+- **Wait for Deduplicate Entry Metadata** — pauses the **duplicate** branch until
+  the original attaches metadata, then continues with it. Place it after a
+  condition on `duplicate` (not directly wired to Deduplicate — see validation
+  below). Waits up to **30 minutes**, and ends early if the entry expires first.
+  Branch on whether `metadata` is present to tell success from every other
+  outcome; `existed_during_wait` distinguishes "expired while waiting" from "never
+  existed" (usually a key mismatch).
+
+---
+
+## Rate Limit family
+
+Pace a workflow against a shared, named budget so it never exceeds what a
+downstream system accepts. The distinguishing feature: **a Rate Limit action can
+pause the workflow.** By default it waits until a slot is free, then continues.
+
+Four actions:
+
+| Action | What it does |
+|--------|--------------|
+| **Rate Limit** | Requests one slot. Proceeds now, waits if a slot frees within `max_wait`, or sheds. |
+| **View Rate Limit** | Reports config, current headroom, and time to next slot. Consumes nothing. |
+| **Delete Rate Limit** | Removes a limiter, resetting its state. |
+| **View All Rate Limits** | Lists every limiter in a scope, plus quota usage. |
+
+### Rate Limit
+
+Inputs: `scope` (required, `definition`/`cid`), `key` (required), `limit`
+(required, positive integer), `every` (required window, default `1m`),
+`tolerance` (`smooth` default / `bursty`), `max_wait` ("Wait Timeout", required).
+`every` and `max_wait` accept `1s`–`24h`.
+
+`limit` + `every` define the rate (`100` every `1m` = 100/min). Three outcomes:
+
+1. **Admitted immediately** — a slot is free. `waited: 0`,
+   `exceeded_wait_timeout: false`.
+2. **Admitted after a wait** — a slot opens within `max_wait`; the workflow
+   suspends and resumes. `waited` reports the block, `exceeded_wait_timeout:
+   false`.
+3. **Shed** — no slot within `max_wait`. Returns **immediately and successfully**
+   with `exceeded_wait_timeout: true` and `retry_after` set to how long the wait
+   *would* have been.
+
+> **Shedding is a success, not an error.** If you do not branch on
+> `exceeded_wait_timeout`, the workflow carries on and calls the downstream system
+> anyway — defeating the rate limit. Always add a condition after a Rate Limit
+> action.
+
+**Tolerance:** `smooth` (default) paces evenly — a limit of N per window admits
+one request every `window / N`, spreading bursts. `bursty` is a token bucket of
+depth `limit` — up to `limit` go back-to-back, then one refills every `window /
+N`.
+
+**Scopes add up.** Three `definition`-scoped limiters of 10/min against the same
+vendor permit 30/min in aggregate — three independent budgets. Only a `cid`-scoped
+limiter keeps their combined rate under one budget. Scope the limiter the way the
+thing you are protecting is shared: a per-tenant vendor quota wants `cid`; pacing
+one workflow's own side effects wants `definition`.
+
+### View / Delete / View All
+
+- **View Rate Limit** — inspects one limiter without consuming a slot. Returns
+  `exists`, and when it exists `limit` / `remaining` / `retry_after`. Not
+  race-safe for "check then call"; use for diagnostics.
+- **Delete Rate Limit** — removes a limiter and frees its quota slot. Resets
+  pacing (grants a fresh burst), so use for housekeeping, not to skip the queue.
+- **View All Rate Limits** — lists `{key, limit, remaining, retry_after}` per
+  limiter plus `quota` fields.
+
+---
+
+## Save-time validation
+
+The builder checks these when you save (keys compared as text, `definition` scope
+only — CID entries are usually claimed by another workflow, and two expressions
+that happen to resolve to the same key are not caught):
+
+- **Deduplicate** — warns if two Deduplicate actions share scope + key but
+  disagree on `period` (whichever runs second has its period ignored); errors if a
+  metadata action has no Deduplicate upstream; warns if a Deduplicate is wired
+  straight into Wait (with no `duplicate` condition between, the wait also runs on
+  the non-duplicate branch and waits on itself for the full timeout).
+- **Rate Limit** — warns if two Rate Limit actions share scope + key but disagree
+  on `limit`, `every`, or `tolerance`. `max_wait` may legitimately differ and is
+  excluded.
+
+## Quotas & cleanup
+
+Each CID may hold a bounded number of active entries/limiters across all scopes
+(default **10,000** each). At the quota, calls that would create a *new*
+entry/limiter fail; calls against existing ones keep working.
+
+- Deduplicate entries expire when `period` elapses (`0` = never — delete
+  explicitly). Deleting a workflow definition removes its entries.
+- Rate limiters are self-cleaning: a limiter goes idle and expires ~5 minutes
+  after its last reservation. Deleting a definition removes its limiters.
+- Avoid unbounded key spaces (timestamps, random IDs) — they create a new
+  entry/limiter every time and never coordinate anything.
+
+## Worked example
+
+`examples/tutorials/intro-deduplicate-third-party-detections.yaml` — an NG-SIEM
+third-party (Palo Alto) detection is deduplicated on a sha1 key over a 24h window:
+new detections create a case and record its ID as metadata; duplicates wait for
+that metadata and comment on the original case.


### PR DESCRIPTION
Adds skills coverage for the two new built-in coordination actions in Falcon Fusion: **Deduplicate** (an atomic once-only claim on a key — "have I already handled this?") and **Rate Limit** (pace a workflow against a shared budget — "am I going too fast?"). Both are inline actions with no Foundry app, `config_id`, or credential.

**What's included**

- An authoring reference (`skills/authoring/references/deduplicate-ratelimit.md`) covering all six Deduplicate activities and all four Rate Limit activities: the scope model, the atomic claim and metadata handoff, quota/shedding behavior, and the save-time validation the builder runs.
- A worked tutorial example (`intro-deduplicate-third-party-detections.yaml`) that suppresses duplicate third-party (Palo Alto) NG-SIEM detections into a single case, keyed on a sha1 of detection type plus source/destination IPs over a 24h window.
- Registration in the reference index and example catalog.

**The scope gotcha, documented up front**

The console labels the two scopes "Workflow" and "CID", but the value the platform stores in YAML is `definition` (per-workflow) and `cid` (tenant-wide) — not `workflow`. Authoring `scope: workflow` from the console label does not match. The reference leads with this so authors write what the platform accepts.

**Verification**

Action IDs and version constraints were confirmed against a live tenant with `action_search.py` (`Deduplicate` declares `semantic_version: 2.2.0`, so `version_constraint: ~2`; the rest are `~1`). The example passes `validate.py` at all tiers, including server-side API validation. The actions are enabled in all commercial CIDs, available in US-1, US-2, and EU-1 by default and in other environments by request.
