### PR TITLE
Correct three authoring-doc claims flagged in tech review (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Throttling reference in the execution skill: explains that a workflow stuck "in progress" may be throttled (Fusion paces an action past a volume limit, auto-retrying up to 6 hours) rather than failed, how to recognize it on the execution detail view, and when sustained throttling signals a workflow-design issue.
 - Deduplicate and Rate Limit action reference plus a worked tutorial example. Covers all six Deduplicate activities and all four Rate Limit activities: the `definition`/`cid` scope values (which the console labels "Workflow" and "CID"), the atomic claim, metadata handoff, and the save-time validation the builder runs. The example deduplicates third-party NG-SIEM detections into a single case. Action IDs were confirmed against a live tenant; the example passes validation at all tiers.
 
+### Fixed
+
+- Three authoring-doc corrections from a Fusion engineer's tech review. `version_constraint` is no longer framed as class-specific — nearly every action carries one whether or not it declares a `class`, so include it on every action node. The event-trigger and system-level variables (`Trigger.CID`, `Workflow.Execution.ID`, `Workflow.Definition.Name`, etc.) are now shown in the `${data['...']}` form and are documented as living in the `data` namespace like any other field rather than as an exception. And the action `name:` field is described as a relabelable display label — renaming it does not break references, which resolve by node key and action `id`.
+
 ## [1.0.1] - 2026-08-07
 
 ### Fixed

--- a/skills/authoring/SKILL.md
+++ b/skills/authoring/SKILL.md
@@ -153,8 +153,8 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/python.sh scripts/action_search.py --details <acti
 ```
 
 For each action you discover, record: `id` (32-char hex), `name`, input
-fields/types, whether it has a `class` (needs `version_constraint`), and whether
-it is a plugin action (needs a `config_id`).
+fields/types, its `version_constraint` (nearly all have one), `class` if any,
+and whether it is a plugin action (needs a `config_id`).
 
 > If a long-lived local cache might be hiding newly shipped actions, refresh it:
 > `${CLAUDE_PLUGIN_ROOT}/scripts/python.sh scripts/action_search.py --clear-cache`. The cache also auto-refreshes
@@ -252,7 +252,7 @@ force an immediate refresh so newly shipped action types are never hidden.
 | "I can guess the action ID format." | WRONG. IDs are 32-char hex, only discoverable via the table or the live API. |
 | "The template has `PLACEHOLDER_RAN_006`, I'll copy it." | NEVER. Templates are structural guides. Substitute a real value before saving. |
 | "Validation can wait until deploy." | NO. Validate after authoring — `validate.py` catches PLACEHOLDERs, bad IDs, and schema errors locally. |
-| "This action has a `class`, version_constraint is optional." | WRONG. Class-based actions REQUIRE `version_constraint`. Missing it fails import. |
+| "Only class-based actions need `version_constraint`." | WRONG. Not class-specific — nearly every action has a `version_constraint`. |
 | "I'll use `~1` everywhere for version_constraint." | NO. The value is `~<major>` of the action's `semantic_version` (`~0` when it declares none): `1.0.4` → `~1`, `0.0.100` → `~0`. Read it from `--details`. |
 | "I'll make up a `config_id` for this Okta action." | NEVER. It's CID-specific (exists only once configured in the console). Ask the user (AskUserQuestion) — even non-interactively. Sequential/all-zeros/repeated-char UUIDs are still fabricated and fail at runtime; can't get a real one? STOP. See `references/best-practices.md`. |
 | "I'll set `definition_id: VIRUSTOTAL_..._ID` on this HTTP action." | NEVER. An `Inline.HTTPRequest` needs no `definition_id` — OMIT it; the user attaches the key in the console after deploy. A placeholder is a broken ref `validate.py` flags. |

--- a/skills/authoring/references/yaml-schema.md
+++ b/skills/authoring/references/yaml-schema.md
@@ -72,7 +72,7 @@ Each action is a named node with a unique label (PascalCase recommended).
 actions:
     ContainDevice:                  # Node label — referenced by next/conditions
         id: bec9fbeb...            # 32-char hex from the action catalog (global, not per-CID)
-        name: Contain device        # Display name (must match catalog name)
+        name: Contain device        # Display label — defaults to the catalog name, but you can rename it freely (next:/conditions resolve by node key and id, not this label)
         next:                       # Next node(s) to execute
             - UpdateVariable
         properties:                 # Action-specific inputs
@@ -101,7 +101,7 @@ CreateVariable:
             required:
                 - my_field
             type: object
-    version_constraint: ~1          # REQUIRED for class-based actions
+    version_constraint: ~1          # Nearly every action needs a version_constraint, not just class-based ones
 ```
 
 ```yaml
@@ -395,10 +395,20 @@ plus a `cs.ip.valid` input gate) and `examples/threat-intel/domain-enrichment-vi
 ### Custom variable
 - `${data['WorkflowCustomVariable.field']}` — read current custom variable value
 
-### Event trigger variables
-- `${Trigger.Category.Investigatable.Product.EPP.Sensor.SensorID}`
-- `${Trigger.Category.Incident.Name}`
-- `${Workflow.Execution.Time}`
+### Event trigger and system variables
+Trigger fields and workflow/system fields (CID, execution ID, definition name,
+etc.) live in the `data` namespace like every other field. Inside string
+interpolation, reference them with the `${data['...']}` form — the system-level
+fields are **not** an exception:
+- `${data['Trigger.Category.Investigatable.Product.EPP.Sensor.SensorID']}`
+- `${data['Trigger.Category.Incident.Name']}`
+- `${data['Trigger.CID']}`
+- `${data['Workflow.Execution.ID']}`
+- `${data['Workflow.Execution.Time']}`
+- `${data['Workflow.Definition.Name']}`
+
+(The bare `${Trigger.X}` form is only for dedicated ID property fields — see the
+interpolation-vs-dedicated-field note in `trigger-types.md`.)
 
 ---
 

--- a/skills/workflows/references/yaml-schema.md
+++ b/skills/workflows/references/yaml-schema.md
@@ -72,7 +72,7 @@ Each action is a named node with a unique label (PascalCase recommended).
 actions:
     ContainDevice:                  # Node label — referenced by next/conditions
         id: bec9fbeb...            # 32-char hex from the action catalog (global, not per-CID)
-        name: Contain device        # Display name (must match catalog name)
+        name: Contain device        # Display label — defaults to the catalog name, but you can rename it freely (next:/conditions resolve by node key and id, not this label)
         next:                       # Next node(s) to execute
             - UpdateVariable
         properties:                 # Action-specific inputs
@@ -101,7 +101,7 @@ CreateVariable:
             required:
                 - my_field
             type: object
-    version_constraint: ~1          # REQUIRED for class-based actions
+    version_constraint: ~1          # Nearly every action needs a version_constraint, not just class-based ones
 ```
 
 ```yaml
@@ -399,10 +399,20 @@ plus a `cs.ip.valid` input gate) and `examples/threat-intel/domain-enrichment-vi
 ### Custom variable
 - `${data['WorkflowCustomVariable.field']}` — read current custom variable value
 
-### Event trigger variables
-- `${Trigger.Category.Investigatable.Product.EPP.Sensor.SensorID}`
-- `${Trigger.Category.Incident.Name}`
-- `${Workflow.Execution.Time}`
+### Event trigger and system variables
+Trigger fields and workflow/system fields (CID, execution ID, definition name,
+etc.) live in the `data` namespace like every other field. Inside string
+interpolation, reference them with the `${data['...']}` form — the system-level
+fields are **not** an exception:
+- `${data['Trigger.Category.Investigatable.Product.EPP.Sensor.SensorID']}`
+- `${data['Trigger.Category.Incident.Name']}`
+- `${data['Trigger.CID']}`
+- `${data['Workflow.Execution.ID']}`
+- `${data['Workflow.Execution.Time']}`
+- `${data['Workflow.Definition.Name']}`
+
+(The bare `${Trigger.X}` form is only for dedicated ID property fields — see the
+interpolation-vs-dedicated-field note in `trigger-types.md`.)
 
 ---
 


### PR DESCRIPTION
Fixes #30.

A Fusion engineer's technical review flagged three factual errors that originated in the authoring skill documentation. This corrects them at the source, in both copies of `yaml-schema.md` (the `authoring` and `workflows` reference sets) plus the authoring `SKILL.md`.

**`version_constraint` is not class-specific.** The Common Pitfalls row and the discovery checklist framed it as a requirement of class-based actions. In reality nearly every action carries a `version_constraint` regardless of whether it declares a `class`, so it belongs on every action node. This changes doc framing only — `validate.py` behavior is unchanged.

**System-level variables are not an exception.** The variable-reference list showed trigger and workflow fields in the bare `${Trigger.X}` form. Those fields live in the `data` namespace like any other field, so the list now uses the `${data['...']}` form (including `Trigger.CID`, `Workflow.Execution.ID`, and `Workflow.Definition.Name`) and notes that the bare form is only for dedicated ID property fields, cross-referencing the existing interpolation-vs-dedicated-field guidance in `trigger-types.md`.

**The action `name:` field is a relabelable display label.** The schema comment said it must match the catalog name. It defaults to the catalog display name but can be renamed freely — `next:`/conditions resolve by the node key and action `id`, not by this label. The separate workflow-level name-stability guidance is unaffected and remains correct.

Verified offline: `test-validate.sh` (56/0), `pytest` (541 passed), markdownlint clean, and the authoring `SKILL.md` stays within the skill size budget.