### PR TITLE
Fail CI on unresolved relative markdown links

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -284,3 +284,36 @@ jobs:
           node-version: 22
       - name: Run markdownlint
         run: npx markdownlint-cli2 "**/*.md"
+      - name: Check relative markdown links resolve
+        # markdownlint checks link SYNTAX, not whether the target exists. This walks
+        # every relative link in a tracked .md and fails on any that does not resolve,
+        # so a moved file or a bad ../ path is caught here instead of only by the
+        # release-time bundle build. Root-relative (/foo) links resolve from the repo
+        # root, as GitHub renders them; external, mailto, and pure-anchor links are skipped.
+        run: |
+          python3 - <<'PY'
+          import os, re, subprocess, sys
+          files = subprocess.check_output(["git", "ls-files", "*.md"], text=True).split()
+          link_re = re.compile(r'\]\(\s*<?([^)>\s]+)')
+          bad = []
+          for f in files:
+              d = os.path.dirname(f)
+              with open(f, encoding="utf-8") as fh:
+                  text = fh.read()
+              for m in link_re.finditer(text):
+                  target = m.group(1)
+                  if target.startswith(("http://", "https://", "mailto:", "tel:", "#")):
+                      continue
+                  path = target.split("#")[0].split("?")[0]
+                  if not path:
+                      continue
+                  resolved = path.lstrip("/") if path.startswith("/") else os.path.join(d, path)
+                  if not os.path.exists(os.path.normpath(resolved)):
+                      bad.append(f"{f}: [{target}] -> {os.path.normpath(resolved)}")
+          if bad:
+              print("Broken relative markdown links:")
+              for b in bad:
+                  print("  " + b)
+              sys.exit(1)
+          print(f"OK: all relative markdown links resolve ({len(files)} files checked)")
+          PY


### PR DESCRIPTION
markdownlint checks link *syntax*, not whether a target *resolves*. Today a broken relative link — a moved file, or a `../` path that no longer resolves after content moves into a `references/` subdirectory — is only caught by `release.sh --bundle`'s link check, which runs at release time after the tag is published. That is a quality gate masquerading as a release gate.

This adds a step to the `markdownlint` job that walks every relative link in a tracked `.md` file and fails on any that does not resolve, reporting all offenders rather than stopping at the first. Root-relative (`/foo`) links resolve from the repo root, as GitHub renders them; external, `mailto:`, and anchor-only links are skipped.

Verified locally: passes on the current tree (55 files, all links resolve), and catches an injected `../does-not-exist.md` — including the depth-aware `references/` case the release-time check was the only thing catching.