### PR TITLE
Emit JSONL from every assistant in the test harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ AI coding assistant skills for building [CrowdStrike Falcon Fusion](https://www.
 | Cursor | `/add-plugin crowdstrike-falcon-fusion` | [Cursor](https://cursor.com/marketplace/crowdstrike) (pending) |
 | Antigravity CLI | `agy plugin install https://github.com/CrowdStrike/fusion-skills` | [Google](https://antigravity.google/docs/plugins) |
 
-In a live-tenant run, Claude Code, Codex, Copilot CLI, and Cursor each authored a valid workflow from the example prompt below and imported it to the tenant. Antigravity CLI loads the skills, but its weekly quota was exhausted before an end-to-end run.
+In a live-tenant run, all five assistants (Claude Code, Codex, Copilot CLI, Cursor, and Antigravity CLI) each authored a valid workflow from the example prompt below and imported it to the tenant.
 
 These skills follow the [Agent Plugins](https://agent-plugins.org) format, with a root `plugin.json` and a Codex `.codex-plugin/plugin.json` so the non-Claude assistants can discover them.
 

--- a/test-assistants.sh
+++ b/test-assistants.sh
@@ -458,7 +458,7 @@ ASSISTANTS=(
   "Codex|codex|~/.agents/skills|exec %%PROMPT%% --skip-git-repo-check --json"
   "Copilot CLI|copilot|--plugin-dir|-p %%PROMPT%% --plugin-dir $REPO --allow-all --output-format json"
   "Cursor|agent|--plugin-dir|-p %%PROMPT%% --plugin-dir $REPO --force --trust --output-format stream-json"
-  "Antigravity CLI|agy|~/.agents/skills|-p %%PROMPT%% --dangerously-skip-permissions"
+  "Antigravity CLI|agy|~/.agents/skills|-p %%PROMPT%% --dangerously-skip-permissions --output-format stream-json"
 )
 
 want() {

--- a/test-assistants.sh
+++ b/test-assistants.sh
@@ -455,8 +455,8 @@ unlink_repo_skills() {
 # repo's symlinks present there. Cursor's CLI binary is `agent` (also installed as `cursor-agent`; both are the same executable).
 ASSISTANTS=(
   "Claude Code|claude|--plugin-dir|-p %%PROMPT%% --plugin-dir $REPO --dangerously-skip-permissions --verbose --output-format stream-json"
-  "Codex|codex|~/.agents/skills|exec %%PROMPT%% --skip-git-repo-check"
-  "Copilot CLI|copilot|--plugin-dir|-p %%PROMPT%% --plugin-dir $REPO --allow-all"
+  "Codex|codex|~/.agents/skills|exec %%PROMPT%% --skip-git-repo-check --json"
+  "Copilot CLI|copilot|--plugin-dir|-p %%PROMPT%% --plugin-dir $REPO --allow-all --output-format json"
   "Cursor|agent|--plugin-dir|-p %%PROMPT%% --plugin-dir $REPO --force --trust --output-format stream-json"
   "Antigravity CLI|agy|~/.agents/skills|-p %%PROMPT%% --dangerously-skip-permissions"
 )


### PR DESCRIPTION
Switches the test harness so all five assistants stream JSON, giving the report parser one output shape to handle. Claude Code and Cursor were already on `--output-format stream-json`; this adds `--json` to Codex, `--output-format json` to Copilot CLI, and `--output-format stream-json` to Antigravity CLI.

Verified end-to-end on a live tenant. In an `--e2e` run scoped to the three changed assistants, Codex, Copilot CLI, and Antigravity CLI each authored a workflow from the canonical prompt and imported it, and every report parsed through the shared `unwrap_log()` helper (skills, `COMMANDS`, and the workflow definition id all extracted). Antigravity was the last unverified leg, since its weekly quota had been exhausted; with quota restored it now passes on stream-json, and its `--e2e` claim capture recorded a real definition id, which confirms both `classify()` and the claim path route through `unwrap_log()`.

Why: cosmetic uniformity, not a bug fix. `unwrap_log()` already normalizes JSON-wrapped and plain-text reports, so there is no functional gap. This just gives every assistant one output shape so future harness edits have a single contract.