### PR TITLE
docs: CEL timestamp/time-math functions + Event Search deep-link pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **CEL timestamp and time-math functions** in the CEL expressions reference — `cs.timestamp.parse(str, 'RFC3339')` plus the live-verified Unix-epoch-millisecond idiom (`int((… - timestamp('1970-01-01T00:00:00Z')).getMilliseconds())`) and `duration(...)` windowing. Includes a case-management pattern for building dynamic, time-scoped Event Search deep links from a detection's `Trigger.ObservedTime`.
+
 ### Fixed
 
 - **`validate.py` now flags `WorkflowCustomVariable.<name>` references to variables that nothing declares** — a release-only failure. A reference to a custom variable that no `CreateVariable` (or `UpdateVariable` setter) declares imports and validates cleanly, then fails at release with `property "..." contains unknown variable "WorkflowCustomVariable.<name>"`. The validator now collects declared variable names and reports an undeclared reference before you deploy.

--- a/skills/authoring/references/cel-expressions.md
+++ b/skills/authoring/references/cel-expressions.md
@@ -92,6 +92,22 @@ Test if a field exists (not null).
 has(data['optional_field'])
 ```
 
+### `cs.timestamp.parse(string, layout)` → timestamp
+Parse a time string into a timestamp. Use `'RFC3339'` for the ISO-8601 times Fusion emits, such as the detection time in `Trigger.ObservedTime`.
+```
+cs.timestamp.parse(data['Trigger.ObservedTime'], 'RFC3339')
+```
+
+Combine it with standard CEL `timestamp()` and `duration()` for time math. To get **Unix epoch milliseconds** — what CQL's `setTimeInterval()` and many external APIs expect — subtract the epoch and take the total milliseconds of the resulting duration, then cast to `int`:
+```
+int((cs.timestamp.parse(data['Trigger.ObservedTime'], 'RFC3339') - timestamp('1970-01-01T00:00:00Z')).getMilliseconds())
+```
+Subtract a `duration(...)` to shift the window — e.g. one hour before the detection:
+```
+int((cs.timestamp.parse(data['Trigger.ObservedTime'], 'RFC3339') - duration('1h') - timestamp('1970-01-01T00:00:00Z')).getMilliseconds())
+```
+`.getMilliseconds()` on a duration returns the **total** milliseconds, not a 0–999 component. Verified live: an `ObservedTime` of `2026-08-21T12:00:00Z` yields `1787313600000` (end) and `1787310000000` (start, one hour earlier).
+
 ---
 
 ## YAML quoting rules — critical gotchas

--- a/skills/workflows/references/cel-expressions.md
+++ b/skills/workflows/references/cel-expressions.md
@@ -92,6 +92,22 @@ Test if a field exists (not null).
 has(data['optional_field'])
 ```
 
+### `cs.timestamp.parse(string, layout)` → timestamp
+Parse a time string into a timestamp. Use `'RFC3339'` for the ISO-8601 times Fusion emits, such as the detection time in `Trigger.ObservedTime`.
+```
+cs.timestamp.parse(data['Trigger.ObservedTime'], 'RFC3339')
+```
+
+Combine it with standard CEL `timestamp()` and `duration()` for time math. To get **Unix epoch milliseconds** — what CQL's `setTimeInterval()` and many external APIs expect — subtract the epoch and take the total milliseconds of the resulting duration, then cast to `int`:
+```
+int((cs.timestamp.parse(data['Trigger.ObservedTime'], 'RFC3339') - timestamp('1970-01-01T00:00:00Z')).getMilliseconds())
+```
+Subtract a `duration(...)` to shift the window — e.g. one hour before the detection:
+```
+int((cs.timestamp.parse(data['Trigger.ObservedTime'], 'RFC3339') - duration('1h') - timestamp('1970-01-01T00:00:00Z')).getMilliseconds())
+```
+`.getMilliseconds()` on a duration returns the **total** milliseconds, not a 0–999 component. Verified live: an `ObservedTime` of `2026-08-21T12:00:00Z` yields `1787313600000` (end) and `1787310000000` (start, one hour earlier).
+
 ---
 
 ## YAML quoting rules — critical gotchas

--- a/use-cases/case-management.md
+++ b/use-cases/case-management.md
@@ -55,6 +55,30 @@ The Charlotte AI LLM Completion action referenced in step 4 is **not** in the ex
 discover its ID with `action_search.py` (Charlotte AI ships at a low semantic version, so expect
 `version_constraint: ~0`, but verify). Never invent an ID.
 
+## Linking a case to Event Search
+
+Instead of copying query results into the case, you can drop a **dynamic, time-scoped Event Search
+deep link** into the case comment or the body of an external ticket (Jira, ServiceNow). The link
+opens Advanced Event Search pre-scoped to the detection's own time window, rather than to whenever
+the analyst happens to click it.
+
+The Event Search URL carries the CQL query URL-encoded, and `setTimeInterval()` takes epoch-millisecond
+`start`/`end`. Compute those inline with CEL from the detection time (`Trigger.ObservedTime`) — see the
+timestamp section of the CEL expressions reference for the verified epoch-millisecond idiom — and splice
+the pills into the encoded string, between the `%22` (`"`) that wrap each value (`%3D` is `=`, `%2C` is `,`):
+
+```
+...setTimeInterval(end%3D%22${int((cs.timestamp.parse(data['Trigger.ObservedTime'], 'RFC3339') - timestamp('1970-01-01T00:00:00Z')).getMilliseconds())}%22%2Cstart%3D%22${int((cs.timestamp.parse(data['Trigger.ObservedTime'], 'RFC3339') - duration('1h') - timestamp('1970-01-01T00:00:00Z')).getMilliseconds())}%22)...
+```
+
+To build the encoded URL, run the query in Event Search with `start`, `end`, and any pivot field
+(e.g. `User.Name`) left empty, copy the resulting URL out of the address bar, paste it into the action
+body, then insert the CEL pills between the `%22`s. Other dynamic values inject the same way.
+
+Trade-off: a link stays small but goes dead once the events age out of your retention window. If the
+case needs to outlive that, embed the results directly instead (`Add events to case`, or format them
+with `cs.table.markdown()`). This technique was shared in the CrowdStrike Fusion SOAR Developer Community.
+
 ## When to Route Elsewhere
 
 Keep case population in the workflow when the query feeds the case attachment directly. Build a


### PR DESCRIPTION
Documents a genuinely useful Fusion CEL capability the skills did not cover: timestamp parsing and time math. Prompted by a technique shared in the CrowdStrike Fusion SOAR Developer Community, then verified live against a tenant before writing anything down.

## What's added

**CEL expressions reference (both copies)** — a `cs.timestamp.parse(str, 'RFC3339')` entry plus the Unix-epoch-millisecond idiom and `duration(...)` windowing:

```
int((cs.timestamp.parse(data['Trigger.ObservedTime'], 'RFC3339') - timestamp('1970-01-01T00:00:00Z')).getMilliseconds())
```

The note makes explicit that `.getMilliseconds()` on a duration returns **total** milliseconds, not a 0–999 component — the one point that actually needed proving.

**Case-management use case** — a pattern for building a dynamic, time-scoped Event Search deep link by splicing those CEL pills into a URL-encoded CQL `setTimeInterval()` string (with the recipe for producing the encoded URL and the retention-window trade-off).

## Verification

Live-verified before documenting: authored a minimal On-demand workflow using these exact expressions, imported, released, and executed it against a known input. An `ObservedTime` of `2026-08-21T12:00:00Z` produced `end=1787313600000` and `start=1787310000000` (exactly T‑1h), matching an independent computation. The probe workflow was deleted afterward.

Docs only — no scripts, validators, or version change. markdownlint clean; the two `cel-expressions.md` copies are kept in sync.