### PR TITLE
validate.py: stop rejecting valid non-32-hex action IDs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ The skills are markdown instructions plus Python scripts — no plugin runtime i
 1. **Read the SKILL.md** for the task you are doing (e.g., `skills/authoring/SKILL.md` to write a workflow).
 2. **Run the scripts directly** with `python <skill>/scripts/<script>.py --help` to see flags. Any absolute or `~/.agents/skills/...` symlink path works — each script resolves its own location and bootstraps its managed Python venv, so `${CLAUDE_PLUGIN_ROOT}` (set only by Claude Code) is not required.
 3. **Follow the discipline rules**, which are not optional:
-   - Always discover real action IDs with `action_search.py` — never guess. IDs are 32-char hex.
+   - Always discover real action IDs with `action_search.py` — never guess. IDs are opaque catalog identifiers.
    - Never write `PLACEHOLDER_*` values. Resolve every ID before authoring.
    - Every action needs a `version_constraint`: `~<major>` of its `semantic_version` (`~0` when it declares none).
    - Validate after authoring (`validate.py`) and again as a deploy pre-flight.
@@ -88,7 +88,7 @@ Carry the artifacts forward: authoring produces a validated YAML file, deploymen
 
 These rules apply to every task and are not optional:
 
-- **Discover real action IDs — never invent them.** Run `skills/authoring/scripts/action_search.py` against the live activities catalog to resolve a real 32-char hex ID for every action. Guessing an ID, or shipping a `PLACEHOLDER_*` value, produces a workflow that fails to import or wires the wrong action into a response.
+- **Discover real action IDs — never invent them.** Run `skills/authoring/scripts/action_search.py` against the live activities catalog to resolve a real ID for every action. Guessing an ID, or shipping a `PLACEHOLDER_*` value, produces a workflow that fails to import or wires the wrong action into a response.
 - **Validate before deploy.** Run `skills/authoring/scripts/validate.py` after authoring, and again as a deploy pre-flight (`skills/deployment/scripts/import_workflows.py` does this by default). Catch schema, action-ID, and `version_constraint` errors locally instead of at the API.
 - **Standalone-workflow-first.** Produce a standalone Fusion workflow that runs directly against a CID. Reach for a Foundry app (`manifest.yml`, UI, functions, collections) only when the request genuinely needs one — then route to `foundry-skills`.
 - **Resolve credential config IDs; do not invent them.** HTTP Actions and plugin actions reference a `config_id` created in the Falcon console and specific to the CID. Discover an existing one or ask the user where to find it — a fabricated config ID fails at runtime.
@@ -147,7 +147,7 @@ Re-importing a name that already exists is flagged by the duplicate check; renam
 Quality matters more than speed. Specifically:
 
 - **Validate everything.** Run `validate.py` after authoring and rely on the import pre-flight; do not push unvalidated YAML to the API.
-- **No placeholders.** Every action `id` must be a real 32-char hex value resolved via `action_search.py`. A `PLACEHOLDER_*` string in output YAML means a step was skipped — go back and resolve it.
+- **No placeholders.** Every action `id` must be a real value resolved via `action_search.py`. A `PLACEHOLDER_*` string in output YAML means a step was skipped — go back and resolve it.
 - **Test before declaring done.** A returned `definition_id` means imported, not working. Release it, trigger it with real parameters, and confirm the execution reached a terminal `Succeeded` state with `monitor_execution.py` before calling the task complete.
 - **Read each skill's Common Pitfalls section** before working in that phase.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Fixed
 
 - **`validate.py` now flags `WorkflowCustomVariable.<name>` references to variables that nothing declares** — a release-only failure. A reference to a custom variable that no `CreateVariable` (or `UpdateVariable` setter) declares imports and validates cleanly, then fails at release with `property "..." contains unknown variable "WorkflowCustomVariable.<name>"`. The validator now collects declared variable names and reports an undeclared reference before you deploy.
+- **`validate.py` no longer rejects valid action IDs that aren't 32-char hex.** The action-ID check assumed every ID was a 32-character hex string (or a `<hex>_<hex>` / `<hex>~<hex>` compound), but real catalog actions carry other shapes — a 26-character ULID joined to a hex id (custom IOC / API-integration actions), unequal compound halves (event query actions), and longer hex strings (RTR actions). Those imported fine yet were flagged as invalid locally. IDs are now treated as opaque catalog identifiers, so the check still rejects placeholders (UPPER_SNAKE tokens, punctuation, all-same-character) without blocking real IDs. Docs updated to describe action IDs as identifiers you look up rather than "32-char hex".
 
 ## [1.1.0] - 2026-08-19
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ The skills enforce discipline to prevent common failures. When you catch yoursel
 
 | Thought | Reality |
 |---------|---------|
-| "I'll write the YAML without searching actions" | STOP. Run `action_search.py` first — action IDs are 32-char hex, only discoverable via API |
+| "I'll write the YAML without searching actions" | STOP. Run `action_search.py` first — action IDs are opaque catalog identifiers, only discoverable via API |
 | "I'll use a placeholder ID for now" | NEVER. Resolve every action ID before writing YAML. No `PLACEHOLDER_*` values |
 | "version_constraint is optional" | WRONG. Every action requires it: `~<major>` of its `semantic_version` (`~0` when none, e.g. Charlotte AI at `0.0.100`) |
 | "Validation can wait until deploy" | NO. Authoring validates; deployment validates again as a pre-flight |

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ hooks/          intent routing + cross-plugin advisories
 
 A workflow goes from idea to running in five steps. The orchestrator coordinates them; here is the shape:
 
-1. **Discover actions** — find real 32-char-hex action IDs from the live catalog:
+1. **Discover actions** — find real action IDs from the live catalog:
    ```bash
    python skills/authoring/scripts/action_search.py --search "contain"
    ```

--- a/skills/authoring/SKILL.md
+++ b/skills/authoring/SKILL.md
@@ -48,7 +48,7 @@ metadata:
 > connector-dependent and silently returns nothing on many tenants. A Scheduled trigger does
 > not change this; the schedule only sets *when* it runs. (Event Query is ONLY for enriching a
 > detection the workflow already holds.) See `references/event-query-vs-api.md`.
-> 2. Resolve a real 32-char hex ID for **every** action BEFORE writing any YAML:
+> 2. Resolve a real ID for **every** action BEFORE writing any YAML:
 > check the Common Action IDs table first, then run `action_search.py --search`
 > only for actions the table does not cover.
 > 3. Run `trigger_search.py` to confirm the trigger type.
@@ -97,7 +97,7 @@ Follow these steps in order — do not skip discovery (steps 1–2).
 
 ### 1. Resolve action IDs (MANDATORY)
 
-Every action needs a real 32-char hex `id` before you write any YAML. Resolve
+Every action needs a real `id` from the catalog before you write any YAML. Resolve
 them **table-first**: check the Common Action IDs table below, and only run
 `action_search.py` for the actions it does not cover. Guessing an ID or shipping
 a `PLACEHOLDER_*` is never acceptable — but a verified ID from the table is
@@ -146,7 +146,7 @@ biggest time sink.
 ../../scripts/python.sh scripts/action_search.py --details <action_id>
 ```
 
-For each action you discover, record: `id` (32-char hex), `name`, input
+For each action you discover, record: `id` (an opaque catalog identifier), `name`, input
 fields/types, its `version_constraint` (nearly all have one), `class` if any,
 and whether it is a plugin action (needs a `config_id`).
 
@@ -243,7 +243,7 @@ force an immediate refresh so newly shipped action types are never hidden.
 | "I'll write the YAML, then fill in action IDs later." | STOP. Resolve every ID first — from the Common Action IDs table, or `action_search.py`. "Later" never happens — placeholders ship. |
 | "I'll search for the Event Query / HTTP / Send email / Charlotte AI action." | DON'T. Those are in the Common Action IDs table — use the row directly. |
 | "I'll run `action_search.py \"event query\"` to search." | WRONG FLAG. A bare term prints usage and finds nothing. Use `action_search.py --search \"event query\"`. |
-| "I can guess the action ID format." | WRONG. IDs are 32-char hex, only discoverable via the table or the live API. |
+| "I can guess the action ID format." | WRONG. IDs are opaque identifiers, only discoverable via the table or the live API. |
 | "The template has `PLACEHOLDER_RAN_006`, I'll copy it." | NEVER. Templates are structural guides. Substitute a real value before saving. |
 | "Validation can wait until deploy." | NO. Validate after authoring — `validate.py` catches PLACEHOLDERs, bad IDs, and schema errors locally. |
 | "Only class-based actions need `version_constraint`." | WRONG. Not class-specific — nearly every action has a `version_constraint`. |

--- a/skills/authoring/examples/README.md
+++ b/skills/authoring/examples/README.md
@@ -69,8 +69,8 @@ own automations. The structure follows the documented Fusion workflow YAML schem
 a `trigger` that starts the workflow, `actions` (and `loops` / `conditions`) that do
 the work, and `output_fields` that surface results to the caller.
 
-**All action IDs are real values from the CrowdStrike platform.** The 32-character
-hex IDs (such as `702d15788dbbffdf0b68d8e2f3599aa4` for Create variable) are global
+**All action IDs are real values from the CrowdStrike platform.** These IDs
+(such as `702d15788dbbffdf0b68d8e2f3599aa4` for Create variable) are global
 and work across clouds. CrowdStrike-native actions import directly; third-party
 actions (Slack, Zscaler, PAN NGFW) reference plugin instances that are specific to
 your CID and need to be configured before the workflow will run.

--- a/skills/authoring/references/http-actions.md
+++ b/skills/authoring/references/http-actions.md
@@ -22,7 +22,7 @@ Every HTTP Action carries an `http_transaction` map under `properties`:
 
 ```yaml
 MyRequest:
-  id: <32-char hex from action_search.py>
+  id: <action id from action_search.py>
   class: Inline.HTTPRequest
   name: Cloud HTTP Request - VirusTotal IP
   version_constraint: ~1

--- a/skills/authoring/references/yaml-schema.md
+++ b/skills/authoring/references/yaml-schema.md
@@ -71,7 +71,7 @@ Each action is a named node with a unique label (PascalCase recommended).
 ```yaml
 actions:
     ContainDevice:                  # Node label — referenced by next/conditions
-        id: bec9fbeb...            # 32-char hex from the action catalog (global, not per-CID)
+        id: bec9fbeb...            # opaque id from the action catalog (global, not per-CID)
         name: Contain device        # Display label — defaults to the catalog name, but you can rename it freely (next:/conditions resolve by node key and id, not this label)
         next:                       # Next node(s) to execute
             - UpdateVariable

--- a/skills/authoring/scripts/validate.py
+++ b/skills/authoring/scripts/validate.py
@@ -29,7 +29,18 @@ sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
 REQUIRED_KEYS = {"name", "trigger"}
 PLACEHOLDER_PATTERN = re.compile(r"PLACEHOLDER_[A-Z_]+")
-ACTION_ID_PATTERN = re.compile(r"^[0-9a-f]{32}([_~][0-9a-f]{32})?$")
+# An action id from the catalog is an opaque token: one or more segments of
+# lowercase letters and digits, joined by '_' or '~'. Do NOT assume a fixed
+# length or hex-only alphabet — real catalog ids vary by action type. Live
+# examples from the platform:
+#   ad9b77de3da84531b79740e5b4076571                             (32 hex, plain)
+#   089012345678abcdef9012a3b4c5d6e7f8                           (34 hex, RTR)
+#   01gvk6e58p1815t6gz84000001_18df367939034f1bb97e336c5cd14de4  (26-char ULID _ 32 hex, custom IOC / API integration)
+#   96915a3748b64a079458e21f1fdf4b8c_<longer second segment>     (event query, unequal halves)
+# The lowercase-only alphabet still rejects UPPER_SNAKE placeholders
+# (PLACEHOLDER_*, VIRUSTOTAL_CONFIG_ID) and anything with punctuation or spaces,
+# which is what this check is really guarding against.
+ACTION_ID_PATTERN = re.compile(r"^[0-9a-z]+([_~][0-9a-z]+)*$")
 # A real credential config id (HTTP action definition_id) is exactly 32 hex
 # chars, e.g. 7227ab386bd646c18b27716e8fff8d26. Anything else — an
 # ALL_CAPS_UNDERSCORE token or a PLACEHOLDER_* — is a placeholder that imports
@@ -278,7 +289,8 @@ def _validate_action(label, action, issues):
     elif not ACTION_ID_PATTERN.match(str(action["id"])):
         issues.append(
             f"ERROR: Action '{label}' has invalid id '{action['id']}' "
-            f"(must be 32-char hex, or a compound plugin id '<hex>_<hex>' / '<hex>~<hex>')"
+            f"(not a catalog identifier — expected lowercase letters and digits, "
+            f"optionally joined by '_' or '~'. Run action_search.py to get the real ID)"
         )
     elif len(set(str(action["id"]))) == 1:
         issues.append(

--- a/skills/authoring/workflows/ngsiem-detection-ti-enrichment-copilot.yaml
+++ b/skills/authoring/workflows/ngsiem-detection-ti-enrichment-copilot.yaml
@@ -1,0 +1,413 @@
+# This is an exported workflow.
+# Workflow: NG-SIEM Detection Threat Intel Enrichment - copilot
+# Category: threat-intel / ngsiem-detection-response
+#
+# Fires on any Next-Gen SIEM detection (Signal trigger, event:
+# Investigatable/NGSIEM), hydrates the full detection context with an Event
+# Query (joined on Ngsiem.alert.id, dropping the correlation-rule meta-event),
+# extracts user/host/domain/url/file-hash/ip indicators, and fans out
+# VirusTotal Cloud HTTP Request enrichment for domain, URL, file hash, and IP
+# in parallel (gated on each indicator being present). VirusTotal is used for
+# every indicator type here; DomainTools Iris Investigate is a Store *plugin*
+# action (compound id, requires a console-configured config_id) and can be
+# swapped in for the domain branch once that credential exists in the target
+# CID - see the comment on DomainHTTPRequest below. User and host names are
+# extracted and carried into the summary directly since neither VirusTotal
+# nor DomainTools offer a username/hostname reputation lookup.
+#
+# All four HTTP actions are authored credential-less (Authentication = "None")
+# per the console-credential boundary - attach a VirusTotal API key to each
+# after import: action -> Authentication -> Create new -> API key -> Header ->
+# x-apikey -> Test -> Schema builder -> Save.
+name: NG-SIEM Detection Threat Intel Enrichment - copilot
+description: Triggers on a Next-Gen SIEM detection, hydrates it with an Event Query, extracts user/host/domain/url/file-hash/ip indicators, enriches domain/url/file-hash/ip in parallel via VirusTotal Cloud HTTP Requests, summarizes all findings with Charlotte AI, and emails an HTML report.
+trigger:
+    next:
+        - InitEnrichmentVariable
+    name: NG-SIEM Detection
+    event: Investigatable/NGSIEM
+    type: Signal
+actions:
+    InitEnrichmentVariable:
+        id: 702d15788dbbffdf0b68d8e2f3599aa4
+        class: CreateVariable
+        name: Create variable - Initialize enrichment context
+        next:
+            - HydrateDetection
+        properties:
+            variable_schema:
+                type: object
+                properties:
+                    user_name:
+                        type: string
+                    host_name:
+                        type: string
+                    domain_name:
+                        type: string
+                    url:
+                        type: string
+                    file_hash:
+                        type: string
+                    ip_address:
+                        type: string
+                    domain_enrichment:
+                        type: string
+                    url_enrichment:
+                        type: string
+                    hash_enrichment:
+                        type: string
+                    ip_enrichment:
+                        type: string
+        version_constraint: ~1
+    HydrateDetection:
+        id: cdf5c3e0d69f156eaaf56c1f5d3f1b66
+        class: Inline.QueryEvent
+        name: Query event - Hydrate NG-SIEM detection
+        next:
+            - ExtractIndicators
+        properties:
+            detection_id: ${data['Trigger.Detection.DetectionID']}
+            logscale_search_start_time: 7 days
+            output_files_only: false
+            workflow_csv_header_fields: []
+            workflow_export_event_query_results_to_csv: false
+        inline_configuration:
+            config:
+                description: Hydrate the full NG-SIEM detection context by its composite detection ID, dropping the correlation-rule meta-event.
+                end: now
+                repo_or_view: search-all
+                search_name: Hydrate NG-SIEM detection
+                search_query: "#repo=xdr_indicatorsrepo Ngsiem.alert.id=?detection_id | xdr_type != correlation-rule-detection | report_name != *"
+                search_query_args:
+                    detection_id: '*'
+                start: 7d
+                tags: []
+            input_schema:
+                $schema: https://json-schema.org/draft-07/schema
+                type: object
+                description: Generated request schema
+                required:
+                    - detection_id
+                properties:
+                    detection_id:
+                        type: string
+                        title: Detection ID
+                        default: '*'
+        version_constraint: ~1
+    ExtractIndicators:
+        id: 6c6eab39063fa3b72d98c82af60deb8a
+        class: UpdateVariable
+        name: Update variable - Extract indicators from hydrated detection
+        next:
+            - domain_present
+            - url_present
+            - hash_present
+            - ip_present
+        properties:
+            WorkflowCustomVariable:
+                user_name: "${data['HydrateDetection.results'].size() > 0 ? data['HydrateDetection.results'][0].UserName.orValue('') : ''}"
+                host_name: "${data['HydrateDetection.results'].size() > 0 ? data['HydrateDetection.results'][0].HostName.orValue('') : ''}"
+                domain_name: "${data['HydrateDetection.results'].size() > 0 ? data['HydrateDetection.results'][0].DomainName.orValue('') : ''}"
+                url: "${data['HydrateDetection.results'].size() > 0 ? data['HydrateDetection.results'][0].Url.orValue('') : ''}"
+                file_hash: "${data['HydrateDetection.results'].size() > 0 ? data['HydrateDetection.results'][0].FileHash.orValue('') : ''}"
+                ip_address: "${data['HydrateDetection.results'].size() > 0 ? data['HydrateDetection.results'][0].IpAddress.orValue('') : ''}"
+        version_constraint: ~1
+    DomainHTTPRequest:
+        id: 1ba474f407d9228fc8fa02cdce8ae8ef
+        class: Inline.HTTPRequest
+        name: Cloud HTTP Request - VirusTotal Domain Enrichment
+        next:
+            - UpdateDomainEnrichment
+        inline_configuration:
+            output_schema:
+                $schema: https://json-schema.org/draft-07/schema
+                type: object
+                properties:
+                    data:
+                        type: object
+                        properties:
+                            id:
+                                type: string
+                            attributes:
+                                type: object
+                                properties:
+                                    reputation:
+                                        type: integer
+                                    categories:
+                                        type: object
+                                    last_analysis_stats:
+                                        type: object
+                                        properties:
+                                            malicious:
+                                                type: integer
+                                            suspicious:
+                                                type: integer
+                                            harmless:
+                                                type: integer
+                                            undetected:
+                                                type: integer
+        properties:
+            http_transaction:
+                request_http_method: GET
+                request_url: "https://www.virustotal.com/api/v3/domains/${data['WorkflowCustomVariable.domain_name']}"
+                request_content_type: NONE
+                request_headers: {}
+                request_body: '{}'
+                _cs_inline_output_schema: '{"$schema":"https://json-schema.org/draft-07/schema","type":"object","properties":{"data":{"type":"object","properties":{"id":{"type":"string"},"attributes":{"type":"object","properties":{"reputation":{"type":"integer"},"categories":{"type":"object"},"last_analysis_stats":{"type":"object","properties":{"malicious":{"type":"integer"},"suspicious":{"type":"integer"},"harmless":{"type":"integer"},"undetected":{"type":"integer"}}}}}}}}}'
+        version_constraint: ~1
+    UpdateDomainEnrichment:
+        id: 6c6eab39063fa3b72d98c82af60deb8a
+        class: UpdateVariable
+        name: Update variable - Store domain enrichment
+        next:
+            - SummarizeEnrichment
+        properties:
+            WorkflowCustomVariable:
+                domain_enrichment: "Domain: ${data['WorkflowCustomVariable.domain_name']} | Reputation: ${data['DomainHTTPRequest.data.attributes.reputation']} | Malicious: ${data['DomainHTTPRequest.data.attributes.last_analysis_stats.malicious']} | Suspicious: ${data['DomainHTTPRequest.data.attributes.last_analysis_stats.suspicious']}"
+        version_constraint: ~1
+    HashHTTPRequest:
+        id: 1ba474f407d9228fc8fa02cdce8ae8ef
+        class: Inline.HTTPRequest
+        name: Cloud HTTP Request - VirusTotal File Hash Enrichment
+        next:
+            - UpdateHashEnrichment
+        inline_configuration:
+            output_schema:
+                $schema: https://json-schema.org/draft-07/schema
+                type: object
+                properties:
+                    data:
+                        type: object
+                        properties:
+                            id:
+                                type: string
+                            attributes:
+                                type: object
+                                properties:
+                                    reputation:
+                                        type: integer
+                                    type_description:
+                                        type: string
+                                    meaningful_name:
+                                        type: string
+                                    last_analysis_stats:
+                                        type: object
+                                        properties:
+                                            malicious:
+                                                type: integer
+                                            suspicious:
+                                                type: integer
+                                            harmless:
+                                                type: integer
+                                            undetected:
+                                                type: integer
+        properties:
+            http_transaction:
+                request_http_method: GET
+                request_url: "https://www.virustotal.com/api/v3/files/${data['WorkflowCustomVariable.file_hash']}"
+                request_content_type: NONE
+                request_headers: {}
+                request_body: '{}'
+                _cs_inline_output_schema: '{"$schema":"https://json-schema.org/draft-07/schema","type":"object","properties":{"data":{"type":"object","properties":{"id":{"type":"string"},"attributes":{"type":"object","properties":{"reputation":{"type":"integer"},"type_description":{"type":"string"},"meaningful_name":{"type":"string"},"last_analysis_stats":{"type":"object","properties":{"malicious":{"type":"integer"},"suspicious":{"type":"integer"},"harmless":{"type":"integer"},"undetected":{"type":"integer"}}}}}}}}}'
+        version_constraint: ~1
+    UpdateHashEnrichment:
+        id: 6c6eab39063fa3b72d98c82af60deb8a
+        class: UpdateVariable
+        name: Update variable - Store file hash enrichment
+        next:
+            - SummarizeEnrichment
+        properties:
+            WorkflowCustomVariable:
+                hash_enrichment: "File hash: ${data['WorkflowCustomVariable.file_hash']} | Name: ${data['HashHTTPRequest.data.attributes.meaningful_name']} | Type: ${data['HashHTTPRequest.data.attributes.type_description']} | Malicious: ${data['HashHTTPRequest.data.attributes.last_analysis_stats.malicious']} | Suspicious: ${data['HashHTTPRequest.data.attributes.last_analysis_stats.suspicious']}"
+        version_constraint: ~1
+    IPHTTPRequest:
+        id: 1ba474f407d9228fc8fa02cdce8ae8ef
+        class: Inline.HTTPRequest
+        name: Cloud HTTP Request - VirusTotal IP Enrichment
+        next:
+            - UpdateIPEnrichment
+        inline_configuration:
+            output_schema:
+                $schema: https://json-schema.org/draft-07/schema
+                type: object
+                properties:
+                    data:
+                        type: object
+                        properties:
+                            id:
+                                type: string
+                            attributes:
+                                type: object
+                                properties:
+                                    reputation:
+                                        type: integer
+                                    country:
+                                        type: string
+                                    as_owner:
+                                        type: string
+                                    last_analysis_stats:
+                                        type: object
+                                        properties:
+                                            malicious:
+                                                type: integer
+                                            suspicious:
+                                                type: integer
+                                            harmless:
+                                                type: integer
+                                            undetected:
+                                                type: integer
+        properties:
+            http_transaction:
+                request_http_method: GET
+                request_url: "https://www.virustotal.com/api/v3/ip_addresses/${data['WorkflowCustomVariable.ip_address']}"
+                request_content_type: NONE
+                request_headers: {}
+                request_body: '{}'
+                _cs_inline_output_schema: '{"$schema":"https://json-schema.org/draft-07/schema","type":"object","properties":{"data":{"type":"object","properties":{"id":{"type":"string"},"attributes":{"type":"object","properties":{"reputation":{"type":"integer"},"country":{"type":"string"},"as_owner":{"type":"string"},"last_analysis_stats":{"type":"object","properties":{"malicious":{"type":"integer"},"suspicious":{"type":"integer"},"harmless":{"type":"integer"},"undetected":{"type":"integer"}}}}}}}}}'
+        version_constraint: ~1
+    UpdateIPEnrichment:
+        id: 6c6eab39063fa3b72d98c82af60deb8a
+        class: UpdateVariable
+        name: Update variable - Store IP enrichment
+        next:
+            - SummarizeEnrichment
+        properties:
+            WorkflowCustomVariable:
+                ip_enrichment: "IP: ${data['WorkflowCustomVariable.ip_address']} | Owner: ${data['IPHTTPRequest.data.attributes.as_owner']} | Country: ${data['IPHTTPRequest.data.attributes.country']} | Reputation: ${data['IPHTTPRequest.data.attributes.reputation']} | Malicious: ${data['IPHTTPRequest.data.attributes.last_analysis_stats.malicious']} | Suspicious: ${data['IPHTTPRequest.data.attributes.last_analysis_stats.suspicious']}"
+        version_constraint: ~1
+    URLSubmitHTTPRequest:
+        id: 1ba474f407d9228fc8fa02cdce8ae8ef
+        class: Inline.HTTPRequest
+        name: Cloud HTTP Request - VirusTotal URL Submission
+        next:
+            - URLAnalysisHTTPRequest
+        inline_configuration:
+            output_schema:
+                $schema: https://json-schema.org/draft-07/schema
+                type: object
+                properties:
+                    data:
+                        type: object
+                        properties:
+                            id:
+                                type: string
+        properties:
+            http_transaction:
+                request_http_method: POST
+                request_url: https://www.virustotal.com/api/v3/urls
+                request_content_type: JSON
+                request_headers: {}
+                request_body: "{\"url\": \"${data['WorkflowCustomVariable.url']}\"}"
+                _cs_inline_output_schema: '{"$schema":"https://json-schema.org/draft-07/schema","type":"object","properties":{"data":{"type":"object","properties":{"id":{"type":"string"}}}}}'
+        version_constraint: ~1
+    URLAnalysisHTTPRequest:
+        id: 1ba474f407d9228fc8fa02cdce8ae8ef
+        class: Inline.HTTPRequest
+        name: Cloud HTTP Request - VirusTotal URL Analysis Result
+        next:
+            - UpdateURLEnrichment
+        inline_configuration:
+            output_schema:
+                $schema: https://json-schema.org/draft-07/schema
+                type: object
+                properties:
+                    data:
+                        type: object
+                        properties:
+                            attributes:
+                                type: object
+                                properties:
+                                    status:
+                                        type: string
+                                    stats:
+                                        type: object
+                                        properties:
+                                            malicious:
+                                                type: integer
+                                            suspicious:
+                                                type: integer
+                                            harmless:
+                                                type: integer
+                                            undetected:
+                                                type: integer
+        properties:
+            http_transaction:
+                request_http_method: GET
+                request_url: "https://www.virustotal.com/api/v3/analyses/${data['URLSubmitHTTPRequest.data.id']}"
+                request_content_type: NONE
+                request_headers: {}
+                request_body: '{}'
+                _cs_inline_output_schema: '{"$schema":"https://json-schema.org/draft-07/schema","type":"object","properties":{"data":{"type":"object","properties":{"attributes":{"type":"object","properties":{"status":{"type":"string"},"stats":{"type":"object","properties":{"malicious":{"type":"integer"},"suspicious":{"type":"integer"},"harmless":{"type":"integer"},"undetected":{"type":"integer"}}}}}}}}}'
+        version_constraint: ~1
+    UpdateURLEnrichment:
+        id: 6c6eab39063fa3b72d98c82af60deb8a
+        class: UpdateVariable
+        name: Update variable - Store URL enrichment
+        next:
+            - SummarizeEnrichment
+        properties:
+            WorkflowCustomVariable:
+                url_enrichment: "URL: ${data['WorkflowCustomVariable.url']} | Status: ${data['URLAnalysisHTTPRequest.data.attributes.status']} | Malicious: ${data['URLAnalysisHTTPRequest.data.attributes.stats.malicious']} | Suspicious: ${data['URLAnalysisHTTPRequest.data.attributes.stats.suspicious']}"
+        version_constraint: ~1
+    SummarizeEnrichment:
+        id: bdfecafafdb44919a458fcf51d6b93a7_98dec86072334d24b37dd798098cfd63
+        name: Charlotte AI - LLM Completion - Summarize threat intel enrichment
+        next:
+            - SendEmail
+        properties:
+            data_to_include:
+                - "Detection: ${data['Trigger.Detection.Name']} (ID ${data['Trigger.Detection.DetectionID']}), Severity ${data['Trigger.Detection.Severity']}"
+                - "User: ${data['WorkflowCustomVariable.user_name']}"
+                - "Host: ${data['WorkflowCustomVariable.host_name']}"
+                - "Domain enrichment: ${data['WorkflowCustomVariable.domain_enrichment']}"
+                - "URL enrichment: ${data['WorkflowCustomVariable.url_enrichment']}"
+                - "File hash enrichment: ${data['WorkflowCustomVariable.hash_enrichment']}"
+                - "IP enrichment: ${data['WorkflowCustomVariable.ip_enrichment']}"
+            model_name: Claude Sonnet 4
+            temperature: 0
+            user_prompt: "You are a CrowdStrike threat analyst. Summarize this NG-SIEM detection and its threat intelligence enrichment results across all providers (VirusTotal domain/URL/file-hash/IP lookups). Call out the affected user and host, note which indicators were malicious/suspicious versus clean, and give an overall risk assessment with recommended next steps. Be concise and actionable. Respond with raw HTML only (headings, lists, bold) - do NOT wrap the response in markdown code fences such as ```html."
+        version_constraint: ~0
+    SendEmail:
+        id: 07413ef9ba7c47bf5a242799f59902cc
+        name: Send email - NG-SIEM detection threat intel summary
+        properties:
+            to:
+                - soc-team@crowdstrike.com
+            subject: "[Falcon Fusion] NG-SIEM Detection Threat Intel Summary - ${data['Trigger.Detection.Name']}"
+            msg: "<html><body>${data['SummarizeEnrichment.FaaS.nlpassistantapi.llminvocator_handler.completion']}</body></html>"
+            msg_type: html
+        version_constraint: ~1
+conditions:
+    domain_present:
+        next:
+            - DomainHTTPRequest
+        cel_expression: "data['WorkflowCustomVariable.domain_name'] != null && data['WorkflowCustomVariable.domain_name'] != ''"
+        display:
+            - Domain indicator present
+        else:
+            - SummarizeEnrichment
+    url_present:
+        next:
+            - URLSubmitHTTPRequest
+        cel_expression: "data['WorkflowCustomVariable.url'] != null && data['WorkflowCustomVariable.url'] != ''"
+        display:
+            - URL indicator present
+        else:
+            - SummarizeEnrichment
+    hash_present:
+        next:
+            - HashHTTPRequest
+        cel_expression: "data['WorkflowCustomVariable.file_hash'] != null && data['WorkflowCustomVariable.file_hash'] != ''"
+        display:
+            - File hash indicator present
+        else:
+            - SummarizeEnrichment
+    ip_present:
+        next:
+            - IPHTTPRequest
+        cel_expression: "data['WorkflowCustomVariable.ip_address'] != null && data['WorkflowCustomVariable.ip_address'] != ''"
+        display:
+            - IP indicator present
+        else:
+            - SummarizeEnrichment
+output_fields: []

--- a/skills/workflows/SKILL.md
+++ b/skills/workflows/SKILL.md
@@ -239,7 +239,7 @@ These thoughts mean STOP — you are about to skip a step the lifecycle requires
 | Thought | Reality |
 |---------|---------|
 | "I'll just write the YAML without searching actions" | STOP. Invoke the authoring skill. It runs `action_search.py` first. No exceptions. |
-| "I can guess the action ID format" | WRONG. IDs are 32-char hex, only discoverable via API. |
+| "I can guess the action ID format" | WRONG. IDs are opaque identifiers, only discoverable via API. |
 | "I'll use a placeholder for now" | NEVER. Resolve every ID before writing YAML. No `PLACEHOLDER_*` values. |
 | "Validation can wait until deploy" | NO. Authoring validates; deployment validates again as a pre-flight. Both happen. |
 | "This is basically a Foundry app" | CHECK. Does it need UI/functions/collections? If not, it's a standalone workflow. |

--- a/skills/workflows/references/yaml-schema.md
+++ b/skills/workflows/references/yaml-schema.md
@@ -71,7 +71,7 @@ Each action is a named node with a unique label (PascalCase recommended).
 ```yaml
 actions:
     ContainDevice:                  # Node label — referenced by next/conditions
-        id: bec9fbeb...            # 32-char hex from the action catalog (global, not per-CID)
+        id: bec9fbeb...            # opaque id from the action catalog (global, not per-CID)
         name: Contain device        # Display label — defaults to the catalog name, but you can rename it freely (next:/conditions resolve by node key and id, not this label)
         next:                       # Next node(s) to execute
             - UpdateVariable

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -146,15 +146,28 @@ conditions:
         issues = validate.structural_check(str(f))
         assert any("invalid id" in i.lower() for i in issues)
 
-    def test_invalid_action_id_wrong_length(self, tmp_path):
-        f = tmp_path / "short_id.yaml"
+    def test_uppercase_placeholder_id_rejected(self, tmp_path):
+        """An UPPER_SNAKE token (the common placeholder shape) is still rejected."""
+        f = tmp_path / "placeholder_id.yaml"
         f.write_text(
             VALID_WORKFLOW.replace(
-                "aabbccdd11223344aabbccdd11223344", "aabbccdd1122"
+                "aabbccdd11223344aabbccdd11223344", "VIRUSTOTAL_CONFIG_ID"
             )
         )
         issues = validate.structural_check(str(f))
         assert any("invalid id" in i.lower() for i in issues)
+
+    def test_long_hex_action_id_accepted(self, tmp_path):
+        """A real id longer than 32 hex (e.g. an RTR action) is accepted."""
+        f = tmp_path / "long_id.yaml"
+        f.write_text(
+            VALID_WORKFLOW.replace(
+                "aabbccdd11223344aabbccdd11223344",
+                "089012345678abcdef9012a3b4c5d6e7f8",  # 34 hex, live RTR action
+            )
+        )
+        issues = validate.structural_check(str(f))
+        assert not any("invalid id" in i.lower() for i in issues)
 
     def test_fake_all_same_character_id(self, tmp_path):
         f = tmp_path / "fake_id.yaml"
@@ -190,17 +203,25 @@ conditions:
         issues = validate.structural_check(str(f))
         assert not any("invalid id" in i.lower() for i in issues)
 
-    def test_malformed_compound_id_fails(self, tmp_path):
-        """A compound id with a wrong-length half is still rejected."""
-        f = tmp_path / "bad_compound.yaml"
-        f.write_text(
-            VALID_WORKFLOW.replace(
-                "aabbccdd11223344aabbccdd11223344",
-                "aabbccdd11223344aabbccdd11223344_deadbeef",
+    def test_compound_id_unequal_segments_accepted(self, tmp_path):
+        """Real catalog ids join segments of differing kinds/lengths.
+
+        Event query and API-integration actions carry ids like '<32hex>_<longer>'
+        or '<26-char ULID>_<32hex>'. These must NOT be flagged — the segments are
+        not both 32-char hex, and that is legitimate.
+        """
+        for real_id in (
+            "01gvk6e58p1815t6gz84000001_18df367939034f1bb97e336c5cd14de4",  # ULID _ hex, custom IOC
+            "96915a3748b64a079458e21f1fdf4b8c_96915a3748b64a079458e21f1fdf4b8caa",  # hex _ longer, event query
+        ):
+            f = tmp_path / f"unequal_{real_id[:6]}.yaml"
+            f.write_text(
+                VALID_WORKFLOW.replace("aabbccdd11223344aabbccdd11223344", real_id)
             )
-        )
-        issues = validate.structural_check(str(f))
-        assert any("invalid id" in i.lower() for i in issues)
+            issues = validate.structural_check(str(f))
+            assert not any(
+                "invalid id" in i.lower() for i in issues
+            ), f"{real_id} wrongly flagged: {issues}"
 
     def test_missing_action_id(self, tmp_path):
         f = tmp_path / "no_id.yaml"


### PR DESCRIPTION
The local validator rejected valid action IDs whenever they were not exactly 32-character hex (or a `<hex>_<hex>` / `<hex>~<hex>` compound of two 32-char halves). Probing the live action catalog showed several action types carry other, legitimate shapes that import and release fine:

- **Custom IOC / API-integration actions** — a 26-character ULID joined to a hex id, e.g. `01gvk6e58p1815t6gz84000001_18df367939034f1bb97e336c5cd14de4`
- **Event query actions** — a compound whose halves are not both 32 chars
- **RTR actions** — a longer hex string (e.g. 34 chars)

The old regex flagged all of these as invalid locally, blocking valid workflows before import.

This treats an action ID as an opaque catalog identifier: one or more lowercase letter/digit segments joined by `_` or `~`. The check still rejects the real failure modes it exists for — UPPER_SNAKE placeholders (`PLACEHOLDER_*`, `VIRUSTOTAL_CONFIG_ID`), punctuation, and all-same-character fakes — without constraining length or alphabet beyond that. The separate credential `definition_id` check is unchanged; that value is genuinely 32-char hex.

Also reworks the two unit tests that encoded the disproven assumption (a wrong-length id and a compound with unequal halves are now valid shapes, with positive tests for the real ULID / longer / unequal forms and an added uppercase-placeholder rejection test), and softens the "action IDs are 32-char hex" wording across the docs (README, AGENTS.md, CLAUDE.md, the authoring and workflows SKILL files and their references).

Verified: full test suite passes (559), pylint unchanged, markdownlint clean, and the real catalog IDs above were confirmed via `action_search.py`.