### PR TITLE
docs: point Cursor install at the live marketplace listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ AI coding assistant skills for building [CrowdStrike Falcon Fusion](https://www.
 | Claude Code | `/plugin install crowdstrike-falcon-fusion` | [Anthropic](https://github.com/anthropics/claude-plugins-official) |
 | Codex | `codex plugin add crowdstrike-falcon-fusion` | [OpenAI](https://chatgpt.com/plugins) (pending) |
 | Copilot CLI | `copilot plugin install CrowdStrike/fusion-skills` | [GitHub](https://github.com/marketplace?type=copilot-plugins) |
-| Cursor | `/add-plugin crowdstrike-falcon-fusion` | [Cursor](https://cursor.com/marketplace/crowdstrike) (pending) |
+| Cursor | `/plugins` (CLI) or `/add-plugin crowdstrike-falcon-fusion` (IDE) | [Cursor](https://cursor.com/marketplace/crowdstrike/crowdstrike-falcon-fusion) |
 | Antigravity CLI | `agy plugin install https://github.com/CrowdStrike/fusion-skills` | [Google](https://antigravity.google/docs/plugins) |
 
 In a live-tenant run, all five assistants (Claude Code, Codex, Copilot CLI, Cursor, and Antigravity CLI) each authored a valid workflow from the example prompt below and imported it to the tenant.


### PR DESCRIPTION
Cursor now lists the plugin in its marketplace (`cursor.com/marketplace/crowdstrike/crowdstrike-falcon-fusion`), so the install table drops "(pending)" and deep-links to the listing.

It also corrects the Cursor CLI install command. The interactive install path is `/plugins` — confirmed by the Cursor CLI itself ("use /plugins in interactive mode to install plugins from this marketplace") and by a live install (plugin cached under `cursor-public` at the v1.1.0 tag). `/plugin` (singular) is only the marketplace-management namespace (`/plugin marketplace list | add`), not an install command. The editor `/add-plugin <name>` command is unchanged.