### PR TITLE
docs: point Copilot install at the awesome-copilot listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ AI coding assistant skills for building [CrowdStrike Falcon Fusion](https://www.
 |-----------|---------|-------------|
 | Claude Code | `/plugin install crowdstrike-falcon-fusion` | [Anthropic](https://github.com/anthropics/claude-plugins-official) |
 | Codex | `codex plugin add crowdstrike-falcon-fusion` | [OpenAI](https://chatgpt.com/plugins) (pending) |
-| Copilot CLI | `copilot plugin install CrowdStrike/fusion-skills` | [GitHub](https://github.com/marketplace?type=copilot-plugins) |
+| Copilot CLI | `copilot plugin install CrowdStrike/fusion-skills` | [GitHub](https://awesome-copilot.github.com/plugin/crowdstrike-falcon-fusion/) |
 | Cursor | `/plugins` (CLI) or `/add-plugin crowdstrike-falcon-fusion` (IDE) | [Cursor](https://cursor.com/marketplace/crowdstrike/crowdstrike-falcon-fusion) |
 | Antigravity CLI | `agy plugin install https://github.com/CrowdStrike/fusion-skills` | [Google](https://antigravity.google/docs/plugins) |
 


### PR DESCRIPTION
The Copilot CLI row in the install table linked its Marketplace column at the generic `github.com/marketplace?type=copilot-plugins` search. Searching that page for "crowdstrike" returns only CrowdStrike GitHub Actions (container image scan, Falconutil, FCS CLI, and a mock server); the `crowdstrike-falcon-fusion` Copilot plugin does not appear there at all, so the link sent readers to unrelated results.

This points the link instead at the plugin's [awesome-copilot listing page](https://awesome-copilot.github.com/plugin/crowdstrike-falcon-fusion/), where the plugin is actually published and discoverable, and which stays on a github.com domain. It also matches how the Cursor row already links to a specific listing rather than a search.

The install command is unchanged and verified: `copilot plugin install` accepts the `owner/repo` form (`CrowdStrike/fusion-skills`), and the plugin is listed in the Copilot CLI's default `awesome-copilot` marketplace (`copilot plugin marketplace browse awesome-copilot` shows it).