### PR TITLE
docs: link the Codex OpenAI column to the specific plugin listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,7 @@ AI coding assistant skills for building [CrowdStrike Falcon Fusion](https://www.
 | Antigravity CLI | `agy plugin install https://github.com/CrowdStrike/fusion-skills` | [Google](https://antigravity.google/docs/plugins) |
 
 > [!NOTE]
-> **Codex** uses a different marketplace depending on how you signed in, so no single command works across both today:
->
-> - **API-key / Amazon Bedrock** — the command above (`crowdstrike-falcon-fusion@openai-api-curated`).
-> - **ChatGPT-authenticated** — run `/plugins` and search for `crowdstrike`.
+> **Codex** has two install paths depending on how you signed in. The command above installs from the curated CLI marketplace, which **API-key and Amazon Bedrock** sessions load. If you authenticated Codex with a **ChatGPT** account, that marketplace isn't loaded — instead run `/plugins` inside Codex, search for `crowdstrike`, and install from the results.
 
 In a live-tenant run, all five assistants (Claude Code, Codex, Copilot CLI, Cursor, and Antigravity CLI) each authored a valid workflow from the example prompt below and imported it to the tenant.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ AI coding assistant skills for building [CrowdStrike Falcon Fusion](https://www.
 | Antigravity CLI | `agy plugin install https://github.com/CrowdStrike/fusion-skills` | [Google](https://antigravity.google/docs/plugins) |
 
 > [!NOTE]
-> **Codex** has two install paths depending on how you signed in. The command above installs from the curated CLI marketplace, which **API-key and Amazon Bedrock** sessions load. If you authenticated Codex with a **ChatGPT** account, that marketplace isn't loaded — instead run `/plugins` inside Codex, search for `crowdstrike`, and install from the results.
+> **Codex** uses a different marketplace depending on how you signed in, so no single command works across both today:
+>
+> - **API-key / Amazon Bedrock** — the command above (`crowdstrike-falcon-fusion@openai-api-curated`).
+> - **ChatGPT-authenticated** — `codex plugin add crowdstrike-falcon-fusion@openai-curated`, or run `/plugins` and search for `crowdstrike`.
 
 In a live-tenant run, all five assistants (Claude Code, Codex, Copilot CLI, Cursor, and Antigravity CLI) each authored a valid workflow from the example prompt below and imported it to the tenant.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ AI coding assistant skills for building [CrowdStrike Falcon Fusion](https://www.
 > **Codex** uses a different marketplace depending on how you signed in, so no single command works across both today:
 >
 > - **API-key / Amazon Bedrock** — the command above (`crowdstrike-falcon-fusion@openai-api-curated`).
-> - **ChatGPT-authenticated** — run `/plugins` and search for `crowdstrike` (the `openai-curated` CLI marketplace does not list these plugins yet).
+> - **ChatGPT-authenticated** — run `/plugins` and search for `crowdstrike`.
 
 In a live-tenant run, all five assistants (Claude Code, Codex, Copilot CLI, Cursor, and Antigravity CLI) each authored a valid workflow from the example prompt below and imported it to the tenant.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ AI coding assistant skills for building [CrowdStrike Falcon Fusion](https://www.
 | Assistant | Command | Marketplace |
 |-----------|---------|-------------|
 | Claude Code | `/plugin install crowdstrike-falcon-fusion` | [Anthropic](https://github.com/anthropics/claude-plugins-official) |
-| Codex | `codex plugin add crowdstrike-falcon-fusion@openai-api-curated` | [OpenAI](https://chatgpt.com/plugins) |
+| Codex | `codex plugin add crowdstrike-falcon-fusion@openai-api-curated` | [OpenAI](https://chatgpt.com/plugins/plugins_6a8f7048ed7881918bf5b79011fe2b5e) |
 | Copilot CLI | `copilot plugin install CrowdStrike/fusion-skills` | [GitHub](https://awesome-copilot.github.com/plugin/crowdstrike-falcon-fusion/) |
 | Cursor | `/plugins` (CLI) or `/add-plugin crowdstrike-falcon-fusion` (IDE) | [Cursor](https://cursor.com/marketplace/crowdstrike/crowdstrike-falcon-fusion) |
 | Antigravity CLI | `agy plugin install https://github.com/CrowdStrike/fusion-skills` | [Google](https://antigravity.google/docs/plugins) |

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ AI coding assistant skills for building [CrowdStrike Falcon Fusion](https://www.
 > **Codex** uses a different marketplace depending on how you signed in, so no single command works across both today:
 >
 > - **API-key / Amazon Bedrock** — the command above (`crowdstrike-falcon-fusion@openai-api-curated`).
-> - **ChatGPT-authenticated** — `codex plugin add crowdstrike-falcon-fusion@openai-curated`, or run `/plugins` and search for `crowdstrike`.
+> - **ChatGPT-authenticated** — run `/plugins` and search for `crowdstrike` (the `openai-curated` CLI marketplace does not list these plugins yet).
 
 In a live-tenant run, all five assistants (Claude Code, Codex, Copilot CLI, Cursor, and Antigravity CLI) each authored a valid workflow from the example prompt below and imported it to the tenant.
 


### PR DESCRIPTION
Point the Codex row's OpenAI marketplace link at the plugin's own chatgpt.com listing instead of the generic `/plugins` directory, matching how the Cursor and Copilot rows already link to their specific listings. No other changes — the install command and note are unchanged from main.