### PR TITLE
docs: prep 1.2.0 changelog (heading, drop release-tag links, marketplace entry)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [1.2.0] - TBD
 
 ### Added
 
+- **Installable from the OpenAI/Codex, Cursor, and GitHub Copilot marketplaces.** Beyond the Anthropic marketplace, the plugin is now published to the OpenAI/Codex curated CLI marketplace (`codex plugin add crowdstrike-falcon-fusion@openai-api-curated`; ChatGPT-authenticated Codex installs via `/plugins`), the Cursor marketplace, and the GitHub Copilot (awesome-copilot) directory. The skills-only bundle now ships the square interface icon the OpenAI directory requires, and the README install table links each live listing plus the Falcon Fusion workflows walkthrough.
 - **CEL timestamp and time-math functions** in the CEL expressions reference — `cs.timestamp.parse(str, 'RFC3339')` plus the live-verified Unix-epoch-millisecond idiom (`int((… - timestamp('1970-01-01T00:00:00Z')).getMilliseconds())`) and `duration(...)` windowing. Includes a case-management pattern for building dynamic, time-scoped Event Search deep links from a detection's `Trigger.ObservedTime`.
 
 ### Fixed
@@ -77,7 +78,3 @@ First public release of Falcon Fusion Skills — AI coding assistant skills for 
 ### Editor and CLI Support
 
 - Tested with Claude Code. Experimental setup instructions for Codex, Copilot CLI, Cursor, and Antigravity CLI, written from each tool's own documentation but not yet verified end to end. The skills are plain markdown, so any assistant that reads local files can use them.
-
-[1.1.0]: https://github.com/CrowdStrike/fusion-skills/releases/tag/v1.1.0
-[1.0.1]: https://github.com/CrowdStrike/fusion-skills/releases/tag/v1.0.1
-[1.0.0]: https://github.com/CrowdStrike/fusion-skills/releases/tag/v1.0.0


### PR DESCRIPTION
Three CHANGELOG fixes ahead of the next release:

1. **Head the in-progress section `## [1.2.0] - TBD`** (was `## [Unreleased]`). `release.sh` step 4 does `sed 's/## [<version>] - TBD/## [<version>] - <today>/'` — it only matches the `- TBD` form and never rewrites `[Unreleased]`, so a release would otherwise ship a section literally titled "Unreleased."
2. **Drop the bottom `[x.y.z]:` release-tag links.** `release.sh` doesn't manage them, and they pointed at tags that don't exist until the release is cut (a dead link until then). **foundry-skills' CHANGELOG carries no such links** — matching it keeps the two repos consistent and removes the dead-link problem at the source. (markdownlint still passes.)
3. **Add the marketplace-availability entry.** Since 1.1.0 the plugin became installable from the OpenAI/Codex, Cursor, and GitHub Copilot marketplaces (pending/unlisted at 1.1.0), and the bundle now ships the OpenAI-required interface icon.

Scope: CHANGELOG only; README already current. Version is 1.2.0 (minor: additive features + fixes, nothing breaking).