### PR TITLE
Release v1.2.0

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/CrowdStrike/fusion-skills.git",
-        "ref": "v1.1.0"
+        "ref": "v1.2.0"
       },
       "policy": {
         "installation": "INSTALLED_BY_DEFAULT",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "crowdstrike-falcon-fusion",
       "source": "./",
       "description": "CrowdStrike Falcon Fusion skills for authoring, deploying, and executing Fusion workflows. Includes live action discovery, YAML authoring with schema validation, workflow import and release, execution monitoring, and Falcon Next-Gen SIEM lookup files.",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "author": {
         "name": "CrowdStrike"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crowdstrike-falcon-fusion",
   "description": "CrowdStrike Falcon Fusion skills for authoring, deploying, and executing Fusion workflows. Includes live action discovery, YAML authoring with schema validation, workflow import and release, execution monitoring, and Falcon Next-Gen SIEM lookup files.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "CrowdStrike"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "crowdstrike-falcon-fusion",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "CrowdStrike Falcon Fusion skills for authoring, deploying, and executing Fusion workflows. Includes live action discovery, YAML authoring with schema validation, workflow import and release, execution monitoring, and Falcon Next-Gen SIEM lookup files.",
   "author": {
     "name": "CrowdStrike",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [1.2.0] - TBD
+## [1.2.0] - 2026-09-08
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Falcon Fusion Skills
 
-[![Version](https://img.shields.io/badge/version-1.1.0-blue)](https://github.com/CrowdStrike/fusion-skills/releases/tag/v1.1.0)
+[![Version](https://img.shields.io/badge/version-1.2.0-blue)](https://github.com/CrowdStrike/fusion-skills/releases/tag/v1.2.0)
 [![CI](https://github.com/CrowdStrike/fusion-skills/actions/workflows/main.yml/badge.svg)](https://github.com/CrowdStrike/fusion-skills/actions/workflows/main.yml)
 
 AI coding assistant skills for building [CrowdStrike Falcon Fusion](https://www.crowdstrike.com/en-us/platform/next-gen-siem/falcon-fusion/) workflows. Go from a natural language prompt to a working Fusion workflow — discover real action IDs from the live API, author the YAML, validate it against the platform schema, import it to a CID, and trigger and monitor its execution.

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "crowdstrike-falcon-fusion",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "CrowdStrike Falcon Fusion skills for authoring, deploying, and executing Fusion workflows. Includes live action discovery, YAML authoring with schema validation, workflow import and release, execution monitoring, and Falcon Next-Gen SIEM lookup files.",
   "author": {
     "name": "CrowdStrike",

--- a/release.sh
+++ b/release.sh
@@ -404,7 +404,14 @@ main() {
 
   printf "\n${BLUE}Step 6: Push branch and create PR${RESET}\n"
   git push -u "$remote" "$release_branch"
-  gh pr create --title "Release v${NEXT_VERSION}" --body "Version bump to v${NEXT_VERSION}."
+  # Target the upstream repo explicitly. Without --repo, `gh pr create` aborts
+  # ("No default remote repository has been set") whenever more than one remote
+  # exists (e.g. a personal fork alongside origin). Derive the slug from the same
+  # remote we just pushed to, parsing both SSH and HTTPS URL forms.
+  local repo_slug
+  repo_slug=$(git remote get-url "$remote" | sed -E 's#^(git@github.com:|https://github.com/)##; s#\.git$##')
+  gh pr create --repo "$repo_slug" --base main --head "$release_branch" \
+    --title "Release v${NEXT_VERSION}" --body "Version bump to v${NEXT_VERSION}."
   printf "${GREEN}✓${RESET} PR created\n"
   git checkout main
 

--- a/skills/authoring/SKILL.md
+++ b/skills/authoring/SKILL.md
@@ -10,8 +10,8 @@ description: >
   DO NOT TRIGGER when the request is for a Falcon Foundry app, a UI extension/page,
   an API integration, custom actions from a third-party API, or a manifest.yml —
   those are foundry-skills territory; advise foundry-skills instead of authoring a workflow.
-version: 1.1.0
-updated: 2026-08-19
+version: 1.2.0
+updated: 2026-09-08
 tags: [fusion, soar, workflows, authoring, yaml, validation]
 author: CrowdStrike
 license: MIT

--- a/skills/deployment/SKILL.md
+++ b/skills/deployment/SKILL.md
@@ -6,8 +6,8 @@ description: >
   list existing workflows, check for duplicates, or manage workflow definitions.
   DO NOT TRIGGER for writing YAML (use authoring), executing workflows,
   or monitoring (use execution).
-version: 1.1.0
-updated: 2026-08-19
+version: 1.2.0
+updated: 2026-09-08
 tags: [fusion, soar, workflows, deployment, import, release]
 author: CrowdStrike
 license: MIT

--- a/skills/execution/SKILL.md
+++ b/skills/execution/SKILL.md
@@ -6,8 +6,8 @@ description: >
   get execution results, or debug a workflow failure.
   DO NOT TRIGGER for writing YAML (use authoring) or importing/releasing
   workflows (use deployment).
-version: 1.1.0
-updated: 2026-08-19
+version: 1.2.0
+updated: 2026-09-08
 tags: [fusion, soar, workflows, execution, monitoring, debugging]
 author: CrowdStrike
 license: MIT

--- a/skills/foundry-redirect/SKILL.md
+++ b/skills/foundry-redirect/SKILL.md
@@ -8,8 +8,8 @@ description: >
   together existing actions. This skill declines Foundry-app requests and points to
   the crowdstrike-falcon-foundry plugin, so the redirect works even without Claude
   Code hooks; it yields to the real Foundry plugin when that plugin is also installed.
-version: 1.1.0
-updated: 2026-08-19
+version: 1.2.0
+updated: 2026-09-08
 tags: [fusion, foundry, redirect, routing]
 author: CrowdStrike
 license: MIT

--- a/skills/lookup-files/SKILL.md
+++ b/skills/lookup-files/SKILL.md
@@ -6,8 +6,8 @@ description: >
   or needs help with CQL match() function.
   DO NOT TRIGGER for Fusion workflows, action discovery, or workflow deployment —
   use the workflows/authoring/deployment skills.
-version: 1.1.0
-updated: 2026-08-19
+version: 1.2.0
+updated: 2026-09-08
 tags: [falcon, ngsiem, siem, lookup-files, cql, threat-hunting]
 author: CrowdStrike
 license: MIT

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -4,8 +4,8 @@ description: >
   Configure CrowdStrike Falcon API credentials for the fusion-skills plugin.
   TRIGGER when user asks to set up credentials, configure API access,
   or runs into authentication errors.
-version: 1.1.0
-updated: 2026-08-19
+version: 1.2.0
+updated: 2026-09-08
 tags: [fusion, setup, credentials, configuration]
 author: CrowdStrike
 license: MIT

--- a/skills/workflows/SKILL.md
+++ b/skills/workflows/SKILL.md
@@ -7,8 +7,8 @@ description: >
   workflows without specifying a sub-task.
   DO NOT TRIGGER when user is working in a Foundry app context, mentions manifest.yml,
   or asks to "build a Foundry app" — use foundry-skills instead.
-version: 1.1.0
-updated: 2026-08-19
+version: 1.2.0
+updated: 2026-09-08
 tags: [fusion, soar, workflows, orchestration, lifecycle]
 author: CrowdStrike
 license: MIT


### PR DESCRIPTION
Version bump to **v1.2.0** across the manifests (`.claude-plugin`, `.codex-plugin`, root `plugin.json`, both `marketplace.json`), the README badge, and all SKILL.md files; CHANGELOG `[1.2.0]` dated.

Highlights since 1.1.0:

- **Fixed** — `monitor_execution.py` / `--wait` no longer misreport a successful run (execution-results API returns `Completed`, not `Succeeded`); `validate.py` stops false-rejecting valid non-32-hex action IDs; `validate.py` flags undeclared `WorkflowCustomVariable` references.
- **Added** — installable from the OpenAI/Codex, Cursor, and GitHub Copilot marketplaces; CEL timestamp/time-math functions in the CEL reference.

Also included (2nd commit): **release.sh now targets `origin` explicitly when opening the release PR.** This run of `release.sh` pushed the branch but `gh pr create` aborted ("No default remote repository has been set") because a second remote was present; passing `--repo/--base/--head` derived from the resolved upstream remote makes it robust to extra remotes.

Full notes in CHANGELOG.md.