### PR TITLE
Stop blocking cs.json.decode of Inline.Python output; add transformList + Request Human Input docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [1.3.0] - TBD
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **`.transformList()` in the CEL reference** — the index-aware list transform (`list.transformList(i, v, expr)`) is now documented alongside `.map()`/`.filter()`, with guidance to prefer it over a workflow Loop when reshaping an array in a single action (e.g. adding multiple events/detections to a case, or building a delimited string with `.join(...)`).
+- **Request Human Input Entra ID note** — the human-in-the-loop use case now records that the responder authenticates through Entra ID (including business users who are not Falcon administrators), so approvers must be able to sign in with Entra ID for the approval gate to work.
+
+### Fixed
+
+- **`validate.py` no longer blocks the supported way to consume Inline.Python JSON output.** The validator flagged `${cs.json.decode(data['<action>.output_stdout']).field}` as a release-time failure, but a live probe (released and executed clean) confirmed the platform accepts it — matching the official SOAR guidance to `print(json.dumps(result))` and decode downstream with `cs.json.decode(...)`. The false-positive guard is removed and `inline-python-action.md` now documents the decode-and-dot-index pattern (guard with `cs.json.valid(...)` when stdout may be non-JSON).
+
 ## [1.2.0] - 2026-09-08
 
 ### Added

--- a/skills/authoring/references/cel-expressions.md
+++ b/skills/authoring/references/cel-expressions.md
@@ -34,6 +34,7 @@ and YAML quoting rules learned from building our 30 production workflows.
 
 ```
 list.map(item, expr)         # Transform: [1,2,3].map(x, x * 2) → [2,4,6]
+list.transformList(i, v, expr)  # Transform with index — reshape an array in ONE action (no loop)
 list.filter(item, cond)      # Filter:    [1,2,3].filter(x, x > 1) → [2,3]
 list.exists(item, cond)      # Any match: [1,2,3].exists(x, x > 2) → true
 list.all(item, cond)         # All match: [1,2,3].all(x, x > 0) → true
@@ -43,6 +44,16 @@ list.exists_one(item, cond)  # Exactly one match
 **Real example** (from RAN-004 — extracting host IDs from ThreatGraph results):
 ```
 ${data['GetDevicesIPv4.Connections'].map(item, item.HostID)}
+```
+
+**Prefer `.transformList()` over a workflow Loop for array reshaping.** When you
+need to reshape an array before handing it to an action — e.g. adding multiple
+events or detections to a case, or building a delimited string —
+`.transformList(idx, item, expr)` maps the whole array in a single action instead
+of a Loop node processing one element at a time. Chain `.join('...')` to collapse
+the result to a string:
+```
+${data['MyQuery.results'].transformList(i, e, e.id).join(',')}
 ```
 
 ---

--- a/skills/authoring/references/inline-python-action.md
+++ b/skills/authoring/references/inline-python-action.md
@@ -20,12 +20,16 @@ run_script:
   must `print(...)` its result to stdout.
 - **Outputs:** `output_stdout`, `output_stderr`, `exit_code`, `error`. Read
   stdout downstream as `${data['run_script.output_stdout']}` — never `$(...)`.
-  **Read stdout as a plain string; do NOT wrap it in `cs.json.decode(...)` and
-  dot-index the result** (`${cs.json.decode(data['run_script.output_stdout']).field}`).
-  That form does not resolve at release ("invalid or missing variable
-  definitions"). If a downstream step needs structured fields, prefer reading the
-  source directly (e.g. an Event Query's `results[0].Field`) over parsing Python
-  stdout — see `event-query-action.md`.
+  **For structured output, `print(json.dumps(result))` and decode it downstream
+  with `cs.json.decode(...)`**, dot-indexing the field you need:
+  `${cs.json.decode(data['run_script.output_stdout']).field}`. This resolves at
+  release and at runtime (live-verified — a released on-demand probe executed
+  clean, and the nested form ships in `examples/threat-intel/analyze-enrich-epp-detection-llm.yaml`).
+  It matches the official SOAR guidance (`print(json.dumps(result))` →
+  `cs.json.decode(STDOUT)`). Guard with `cs.json.valid(...)` before decoding if
+  the script can print plain text on some paths. When the value you need already
+  exists on a prior action's output (e.g. an Event Query's `results[0].Field`),
+  reference it directly rather than routing it through Python.
 - **`version_constraint: ~1`.**
 - **Limits:** 60s execution, 256 MB memory, 50,000-char script, input+output
   ≤ 1024 KB, pre-installed packages only.

--- a/skills/authoring/scripts/validate.py
+++ b/skills/authoring/scripts/validate.py
@@ -83,12 +83,6 @@ RELEASE_BAD_REF_PATTERNS = [
      "a Charlotte AI reference with lowercase '.faas.'. Field names are "
      "case-sensitive; release rejects it — use '.FaaS.nlpassistantapi..."
      "'. See references/charlotte-ai-action.md."),
-    (re.compile(r"cs\.json\.decode\(\s*data\['[^']*\.output_stdout'\]\s*\)"),
-     "a cs.json.decode() wrapper around an Inline.Python 'output_stdout' "
-     "reference. Release rejects this as 'invalid or missing variable "
-     "definitions'. Read the source directly instead — e.g. an Event Query's "
-     "${data['<Action>.results'][0].Field} — rather than parsing Python stdout. "
-     "See references/inline-python-action.md and event-query-action.md."),
     (re.compile(r"data\['[^']*\.\d+\.[^']*'\]"),
      "a numeric array index inside the data['...'] quotes (e.g. "
      "'.results.0.field'). Release rejects it as 'not found' — the index goes "

--- a/skills/workflows/references/cel-expressions.md
+++ b/skills/workflows/references/cel-expressions.md
@@ -34,6 +34,7 @@ and YAML quoting rules learned from building our 30 production workflows.
 
 ```
 list.map(item, expr)         # Transform: [1,2,3].map(x, x * 2) → [2,4,6]
+list.transformList(i, v, expr)  # Transform with index — reshape an array in ONE action (no loop)
 list.filter(item, cond)      # Filter:    [1,2,3].filter(x, x > 1) → [2,3]
 list.exists(item, cond)      # Any match: [1,2,3].exists(x, x > 2) → true
 list.all(item, cond)         # All match: [1,2,3].all(x, x > 0) → true
@@ -43,6 +44,16 @@ list.exists_one(item, cond)  # Exactly one match
 **Real example** (from RAN-004 — extracting host IDs from ThreatGraph results):
 ```
 ${data['GetDevicesIPv4.Connections'].map(item, item.HostID)}
+```
+
+**Prefer `.transformList()` over a workflow Loop for array reshaping.** When you
+need to reshape an array before handing it to an action — e.g. adding multiple
+events or detections to a case, or building a delimited string —
+`.transformList(idx, item, expr)` maps the whole array in a single action instead
+of a Loop node processing one element at a time. Chain `.join('...')` to collapse
+the result to a string:
+```
+${data['MyQuery.results'].transformList(i, e, e.id).join(',')}
 ```
 
 ---

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2296,7 +2296,14 @@ actions:
         issues = validate.structural_check(str(f))
         assert any("case-sensitive" in i for i in issues)
 
-    def test_release_ref_cs_json_decode_stdout_flagged(self, tmp_path):
+    def test_cs_json_decode_stdout_not_flagged(self, tmp_path):
+        # Consuming Inline.Python JSON output with cs.json.decode() and
+        # dot-indexing a field is VALID — release accepts it and it resolves at
+        # runtime (live-verified: on-demand probe released and executed clean,
+        # shallow .risk_level and the nested LLM-completion form in
+        # analyze-enrich-epp-detection-llm.yaml both work). Matches the official
+        # SOAR guidance (print(json.dumps(result)) -> cs.json.decode(STDOUT)).
+        # This test guards against re-adding the old false-positive guard.
         f = tmp_path / "jsondecode.yaml"
         content = """\
 # Header
@@ -2316,7 +2323,7 @@ actions:
 """
         f.write_text(content)
         issues = validate.structural_check(str(f))
-        assert any("cs.json.decode" in i and "output_stdout" in i for i in issues)
+        assert not any("cs.json.decode" in i for i in issues)
 
     def test_pinned_long_namespace_path_flagged(self, tmp_path):
         # A pinned action referenced with its output namespace left in the path

--- a/use-cases/human-in-the-loop-containment.md
+++ b/use-cases/human-in-the-loop-containment.md
@@ -42,6 +42,10 @@ products, each with its own approval-then-contain branch.
    "Request human input - Send Slack message" action (id `1ecc2f19f3deb1c607c07a2d755eb538`) that is
    not used in this workflow; discover and confirm it in your CID with
    `action_search.py --search "request human input"` before swapping it in.
+   **Entra ID auth:** the recipient responds through an authenticated prompt, so
+   Request Human Input requires the responder to authenticate with Entra ID —
+   including a business user who is not a Falcon administrator. Confirm the
+   approvers can sign in with Entra ID before relying on this gate.
 5. **Condition on the response.** An FQL condition
    `RequestHumanInputSendEmail.RequestHumanInput.SendEmail.result.user_response:'Approve'` creates
    the true branch. A companion condition matches `Decline` or `Timed out` and routes to a comment


### PR DESCRIPTION
A live probe settled a documentation question that turned out to be a shipped false positive.

**Inline.Python JSON output.** `validate.py` flagged `${cs.json.decode(data['<action>.output_stdout']).field}` as a release-time failure ("invalid or missing variable definitions"), and `inline-python-action.md` told authors not to use it. A minimal on-demand probe — an Inline.Python action running `print(json.dumps({...}))` feeding an `UpdateVariable` that set a variable to `${cs.json.decode(data['CreatePythonScript.output_stdout']).risk_level}` — **released and executed cleanly**. The nested form also already ships in `examples/threat-intel/analyze-enrich-epp-detection-llm.yaml`, and it matches the recommended pattern of `print(json.dumps(result))` then `cs.json.decode(...)` downstream.

This PR:

- Removes the false-positive guard from `validate.py` and converts its negative test into a regression test that asserts the form is **not** flagged.
- Rewrites the Inline.Python reference to document the decode-and-dot-index pattern, with `cs.json.valid(...)` guarding a possibly-non-JSON stdout.
- Documents CEL `.transformList(i, v, expr)` as the index-aware array transform, preferred over a workflow Loop for reshaping an array in a single action (e.g. adding multiple detections to a case).
- Notes that Request Human Input authenticates the responder through Entra ID (including non-administrator business users).

Verification: full test suite (566) passes, `validate.py` structural check no longer flags the decode form, and pylint is 10/10.